### PR TITLE
feat: #50 create an history table for demandes

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -128,7 +128,7 @@ fileignoreconfig:
 - filename: pg/scripts/02/02-3-back-init.sql
   checksum: 5a57a150059114c6819fbbe397d5cb5bc7861234c3768e590cf3cc540d8a224d
 - filename: pg/scripts/02/02-4-front-init.sql
-  checksum: bc1b589d062b8003ad3b7323d397fee3279f79712a52444ae20ce434e9b0939e
+  checksum: 9429e18fde24d0bb8d199ae78fdb782bf9d070840241502eb67326dbe57803aa
 - filename: pg/scripts/03/03-1-geo-data.sql
   checksum: 72d509db1f64cd1e3b95f6696d7243aaa042da5dccff68663100f4d8483aa2d3
 - filename: pg/scripts/03/03-2-back-data.sql

--- a/packages/frontend-usagers/src/pages/demande-sejour/liste.vue
+++ b/packages/frontend-usagers/src/pages/demande-sejour/liste.vue
@@ -138,7 +138,7 @@ const departementOptions = computed(() => {
 const statutOptions = computed(() => {
   return [
     { label: "BROUILLON", value: "BROUILLON" },
-    { label: "TRANMISE", value: "TRANMISE" },
+    { label: "TRANSMISE", value: "TRANSMISE" },
     { label: "EN COURS", value: "EN COURS" },
     { label: "A MODIFIER", value: "A MODIFIER" },
     {

--- a/pg/scripts/02/02-4-front-init.sql
+++ b/pg/scripts/02/02-4-front-init.sql
@@ -40,7 +40,7 @@ create table front.sessions (
 /* Table : operateur                                            */
 /*==============================================================*/
 create table front.operateurs (
-   id                           SERIAL               NOT NULL, 
+   id                           SERIAL               NOT NULL,
    supprime                     BOOLEAN              NOT NULL DEFAULT false,
    complet                      BOOLEAN              NOT NULL DEFAULT false,
    type_operateur               VARCHAR(20)          NOT NULL DEFAULT 'personne_morale',
@@ -80,9 +80,9 @@ CREATE TABLE front.agrements (
    constraint pk_agrements primary key (uuid)
 );
 CREATE TYPE sejour_status AS ENUM (
-   'BROUILLON', 
-   'TRANMISE', 
-   'EN COURS', 
+   'BROUILLON',
+   'TRANSMISE',
+   'EN COURS',
    'A MODIFIER',
    'EN ATTENTE VALIDATION HEBERGEMENT',
    'EN ATTENTE DECLARATION 8 JOURS',
@@ -132,6 +132,24 @@ create table front.hebergement (
    edited_at                    TIMESTAMP            DEFAULT current_timestamp NOT NULL,
    constraint pk_hebergement primary key (id)
 );
+
+/*==============================================================*/
+/* Table : demande_sejour_history                               */
+/*==============================================================*/
+create table front.demande_sejour_history (
+   id                           SERIAL               NOT NULL,
+   source                       VARCHAR(80)          NOT NULL,
+   demande_sejour_id            INTEGER              NOT NULL REFERENCES front.demande_sejour(id),
+   usager_user_id               INTEGER              REFERENCES front.users(id),
+   bo_user_id                   INTEGER              REFERENCES back.users(id),
+   type                         VARCHAR(80)          NOT NULL,
+   type_precision               VARCHAR(80)          ,
+   metadata                     JSONB                ,
+   created_at                   TIMESTAMP            DEFAULT current_timestamp NOT NULL,
+   edited_at                    TIMESTAMP            DEFAULT current_timestamp NOT NULL,
+   constraint pk_demande_sejour_history primary key (id)
+);
+
 
 GRANT USAGE ON SCHEMA front TO vao;
 


### PR DESCRIPTION
L'historique doit renseigner le user qui en est a l'origine. Comme le user peut etre soit un user USAGER, soit un user BO, pour pouvoir faire les bonnes références, on créee deux colonnes nullable correspondant au type de user.