### PR TITLE
fix: Ne pas afficher les demandes en brouillon

### DIFF
--- a/packages/backend/src/controllers/demandeSejour/getByDepartementCodes.js
+++ b/packages/backend/src/controllers/demandeSejour/getByDepartementCodes.js
@@ -4,7 +4,7 @@ const logger = require("../../utils/logger");
 
 const log = logger(module.filename);
 
-module.exports = async function getByAdminId(req, res) {
+module.exports = async function getByDepartementCodes(req, res) {
   log.i("In");
   const { decoded } = req;
   const { id: adminId } = decoded ?? {};
@@ -13,7 +13,7 @@ module.exports = async function getByAdminId(req, res) {
   try {
     const { limit, offset, sortBy, sortDirection, search } = req.query;
 
-    const demandesWithPagination = await DemandeSejour.getByAdminId(
+    const demandesWithPagination = await DemandeSejour.getByDepartementCodes(
       {
         limit,
         offset,

--- a/packages/backend/src/controllers/demandeSejour/index.js
+++ b/packages/backend/src/controllers/demandeSejour/index.js
@@ -1,7 +1,7 @@
 module.exports.get = require("./get");
 module.exports.getById = require("./getById");
 module.exports.getByIdBo = require("./getByIdBo");
-module.exports.getByAdminId = require("./getByAdminId");
+module.exports.getByDepartementCodes = require("./getByDepartementCodes");
 module.exports.post = require("./post");
 module.exports.update = require("./update");
 module.exports.depose = require("./depose");

--- a/packages/backend/src/routes/sejour.js
+++ b/packages/backend/src/routes/sejour.js
@@ -13,7 +13,7 @@ router.get(
   "/admin",
   boCheckJWT,
   getDepartements,
-  demandeSejourController.getByAdminId,
+  demandeSejourController.getByDepartementCodes,
 );
 router.get(
   "/admin/:id",


### PR DESCRIPTION
Close jira 170

 - Je met le filtre directement dans la requete car celle ci ne concerne que le BO et a priori, le BO n'aura jamais accès aux demandes en brouillon
 - j'en ai profité pour faire un peu de renaming sur la requete qui n'est plus vraiment en getByAdminId