### PR TITLE
fix: Page organisme - modale d'ajout d'un représentant légal ne se ferme pas

### DIFF
--- a/packages/frontend-usagers/src/components/personnes.vue
+++ b/packages/frontend-usagers/src/components/personnes.vue
@@ -16,7 +16,7 @@
       :opened="modalPersonne.opened"
       :title="props.title"
       size="md"
-      @close.prevent="onClose"
+      @close="onClose"
     >
       <Personne
         :personne="personne"


### PR DESCRIPTION
close jira 161 (https://jira-mcas.atlassian.net/browse/VAO-161?atlOrigin=eyJpIjoiZjg5YmM3ZjJiOTY2NGMxYmE4YTIzMDM3MmFjNGQxOWYiLCJwIjoiaiJ9)