### PR TITLE
feat: ajout des champs optionnel pour la création de l'organisme

### DIFF
--- a/packages/frontend-usagers/src/components/organisme/agrement.vue
+++ b/packages/frontend-usagers/src/components/organisme/agrement.vue
@@ -1,5 +1,11 @@
 <template>
   <div>
+    <div class="fr-fieldset__element">
+      <span class="fr-hint-text"
+        >Sauf mention contraire “(optionnel)” dans le label, tous les champs
+        sont obligatoires</span
+      >
+    </div>
     <form>
       <fieldset class="fr-fieldset">
         <div class="fr-fieldset__element">
@@ -102,6 +108,7 @@
 <script setup>
 import { useField, useForm } from "vee-validate";
 import * as yup from "yup";
+
 const nuxtApp = useNuxtApp();
 const toaster = nuxtApp.vueApp.$toast;
 

--- a/packages/frontend-usagers/src/components/organisme/informations-generales.vue
+++ b/packages/frontend-usagers/src/components/organisme/informations-generales.vue
@@ -1,5 +1,11 @@
 <template>
   <div>
+    <div class="fr-fieldset__element">
+      <span class="fr-hint-text"
+        >Sauf mention contraire “(optionnel)” dans le label, tous les champs
+        sont obligatoires</span
+      >
+    </div>
     <fieldset class="fr-fieldset">
       <div class="fr-fieldset__element">
         <div class="fr-input-group fr-col-12">

--- a/packages/frontend-usagers/src/components/organisme/personne-morale.vue
+++ b/packages/frontend-usagers/src/components/organisme/personne-morale.vue
@@ -40,7 +40,7 @@
         <div class="fr-fieldset__element">
           <DsfrInputGroup
             name="nomCommercial"
-            label="Nom commercial"
+            label="Nom commercial (optionnel)"
             :label-visible="true"
             :model-value="nomCommercial"
             :is-valid="nomCommercialMeta.valid"

--- a/packages/frontend-usagers/src/components/organisme/personne-physique.vue
+++ b/packages/frontend-usagers/src/components/organisme/personne-physique.vue
@@ -20,7 +20,7 @@
         <div class="fr-input-group fr-col-8">
           <DsfrInputGroup
             name="nomUsage"
-            label="Nom d'usage"
+            label="Nom d'usage (optionnel)"
             :label-visible="true"
             :readonly="!props.modifiable"
             :model-value="nomUsage"

--- a/packages/frontend-usagers/src/components/protocole-sanitaire.vue
+++ b/packages/frontend-usagers/src/components/protocole-sanitaire.vue
@@ -461,7 +461,7 @@
     >
       <UtilsMultiFilesUpload
         v-model="files"
-        label="Merci de joindre les documents requis pour les informations sanitaires"
+        label="Merci de joindre les documents requis pour les informations sanitaires (optionnel)"
         hint="Taille maximale : 5 Mo."
         :modifiable="props.modifiable"
       />

--- a/packages/frontend-usagers/src/components/protocole-transport.vue
+++ b/packages/frontend-usagers/src/components/protocole-transport.vue
@@ -111,7 +111,7 @@
     <DsfrFieldset>
       <UtilsMultiFilesUpload
         v-model="files"
-        label="Merci de joindre les documents requis pour les informations transport"
+        label="Merci de joindre les documents requis pour les informations transport (optionnel)"
         hint="Taille maximale : 5 Mo."
         :modifiable="props.modifiable"
       />


### PR DESCRIPTION
close jira 228 (https://jira-mcas.atlassian.net/browse/VAO-228?atlOrigin=eyJpIjoiNzQ4YWJjYzZlNGM2NDI2ZjgxODA5ODk4NDUxMjBmMzIiLCJwIjoiaiJ9)

Les deux champs “nom d’usage” ne sont pas traités ici car il n’y a pas de champs nom de naissance. il faut remplacer ce champs par nom de naissance et en créer un autre optionnel nom d’usage. Ce sera l’objet du ticket https://jira-mcas.atlassian.net/browse/VAO-273?atlOrigin=eyJpIjoiMWJlZTM2YTQ3ZmJjNGM1MTg5MmYxYThmZTQ4ZDc5ZGYiLCJwIjoiaiJ9
 

screenshot pour le texte introcductif et les 4 champs optionnel (moi les nom d’usage, voir remarque précédente, moins la remarque sur la recuperation des etablissement secondaires sur lesquels on a pas la main)

![image](https://github.com/SocialGouv/vao/assets/139745995/c79279fb-0d14-4851-b3b9-b972534759bf)
![image](https://github.com/SocialGouv/vao/assets/139745995/cd93550b-bd0c-46d4-8977-bdb9084e71b1)
![image](https://github.com/SocialGouv/vao/assets/139745995/8738abf1-be1d-4ae1-b43d-dab0e1636d34)
![image](https://github.com/SocialGouv/vao/assets/139745995/2d6a8762-a454-472b-8ebd-a2d6449a287d)


