### PR TITLE
fix(hebergement): 289-surcharge message d'erreur par défaut

### DIFF
--- a/packages/backend/src/schemas/hebergement.js
+++ b/packages/backend/src/schemas/hebergement.js
@@ -5,7 +5,7 @@ const adresseSchema = require("./parts/adresse.js")({ isFromAPIAdresse: true });
 
 const coordonneesSchema = () => ({
   adresse: yup.object(adresseSchema).required(),
-  email: yup.string().email().nullable(),
+  email: yup.string().email("Format de courriel invalide").nullable(),
   nomGestionnaire: yup.string().required(),
   numTelephone1: telephoneSchema(),
   numTelephone2: telephoneSchema().notRequired(),

--- a/packages/frontend-usagers/src/utils/hebergementUtils.js
+++ b/packages/frontend-usagers/src/utils/hebergementUtils.js
@@ -61,7 +61,7 @@ const coordonneesSchema = {
         numTelephone2 == null || numTelephoneRegex.test(numTelephone2),
     )
     .nullable(),
-  email: yup.string().email().nullable(),
+  email: yup.string().email("Format de courriel invalide").nullable(),
 };
 const informationsLocauxSchema = {
   type: yup


### PR DESCRIPTION
Ajout du message en français pour ne pas avoir de message pas défaut dans les champs de type mail au niveau du yup hébergement(s)