### PR TITLE
fix(organisme): 109 ajout infos etablissements secondaire

### DIFF
--- a/packages/backend/src/controllers/siret/get.js
+++ b/packages/backend/src/controllers/siret/get.js
@@ -72,10 +72,6 @@ module.exports = async function get(req, res, next) {
 
     const etablissements = elements
       .filter((e) => e.uniteLegale.etatAdministratifUniteLegale === "A")
-      .filter(
-        (e) =>
-          e.periodesEtablissement[0].etatAdministratifEtablissement === "A",
-      )
       .filter((e) => e.nic !== uniteLegale.nic)
       .map((e) => {
         return {
@@ -84,6 +80,9 @@ module.exports = async function get(req, res, next) {
           commune: e.adresseEtablissement.libelleCommuneEtablissement ?? "",
           enabled: false,
           nic: e.nic,
+          siret: e.siret,
+          denomination: uniteLegale.uniteLegale.denominationUniteLegale,
+          etatAdministratif: e.periodesEtablissement[0].etatAdministratifEtablissement === "A" ? "En activité": e.periodesEtablissement[0].etatAdministratifEtablissement === "F" ? "Fermé" : "",
         };
       });
 

--- a/packages/frontend-usagers/src/components/organisme/personne-morale.vue
+++ b/packages/frontend-usagers/src/components/organisme/personne-morale.vue
@@ -211,13 +211,17 @@
           <div class="fr-input-group fr-col-12">
             <DsfrTable
               :headers="[
-                'code NIC',
+                'SIRET',
+                'Dénomination',
                 'Adresse',
                 'Code postal',
                 'Commune',
+                'État',
                 'Autorisé à organiser des séjours ?',
               ]"
               :rows="formatedEtablissements"
+              :results-displayed="10"
+              :current-page="currentPage"
               pagination
             />
           </div>
@@ -394,17 +398,19 @@ const formatedEtablissements = computed(() => {
     })
     .map((e, index) => {
       const row = [
-        e.nic,
+        e.siret,
+        e.denomination,
         e.adresse,
         e.codePostal,
         e.commune,
+        e.etatAdministratif,
         {
           component: "DsfrToggleSwitch",
-          modelValue: etablissements.value[index].enabled,
-          disabled: !props.modifiable,
+          modelValue: e.enabled,
+          disabled: (!(props.modifiable) || (!e.enabled && !(e.etatAdministratif == "En activité"))),
           onChange: () => {
-            etablissements.value[index].enabled =
-              !etablissements.value[index].enabled;
+            e.enabled =
+              !e.enabled;
           },
         },
       ];


### PR DESCRIPTION
- Ajout d’un correctif sur la pagination des établissements secondaires
- Suppression du filtrage sur les établissements secondaires Fermés
- Ajout d’une colonne “Etat” avec “En activité” ou “Fermé”
    - Si un établissement est “Fermé” il ne peut alors pas être activé
    - Si un établissement fermé a été activé alors il peut être désactivé (il ne pourra plus être activé)
- Ajout Dénomination dans l'établissement secondaire