### PR TITLE
feat(BOSejour): Accès aux séjours pour profil région donc l'agrément

### DIFF
--- a/packages/backend/src/controllers/demandeSejour/getByDepartementCodes.js
+++ b/packages/backend/src/controllers/demandeSejour/getByDepartementCodes.js
@@ -56,6 +56,7 @@ module.exports = async function getByDepartementCodes(req, res, next) {
     const demandesWithPagination = await DemandeSejour.getByDepartementCodes(
       params,
       req.departements.map((d) => d.value),
+      req.decoded.territoireCode
     );
     log.d(demandesWithPagination);
     return res.status(200).json({ demandesWithPagination });

--- a/packages/backend/src/controllers/demandeSejour/getByIdBo.js
+++ b/packages/backend/src/controllers/demandeSejour/getByIdBo.js
@@ -12,6 +12,7 @@ module.exports = async function getById(req, res, next) {
     const demande = await DemandeSejour.getById(
       demandeId,
       req.departements.map((d) => d.value),
+      req.decoded.territoireCode,
     );
     log.d(demande);
     return res.status(200).json({ demande });


### PR DESCRIPTION
L’accès aux séjours été accordé au profil régional dont dépend l’agrément même pour les séjours ne se déroulant pas dans la région.

Le droit d'écriture ou de lecture est appliqué en fonction de l’option cochée au niveau du profil utilisateur. 
La visibilité et droits pour le profil régional est transverse : Je vois les séjours dans ma région et les séjours pour lesquels l’agrément de l’organisme dépend de ma région et j’ai l’accès en lecture ou écriture suivant mon profil.