### PR TITLE
feat(comptes-bo): 357 Restriction du périmètre géo création comptes BO

### DIFF
--- a/packages/backend/src/controllers/bo-authentication/email/login.js
+++ b/packages/backend/src/controllers/bo-authentication/email/login.js
@@ -55,6 +55,8 @@ module.exports = async function login(req, res, next) {
     );
   }
 
+  user.serviceCompetent = (user.territoireCode === "FRA") ? 'NAT' : (/^[0-9]+$/.test(user.territoireCode)) ? 'DEP' : 'REG';
+
   try {
     const accessToken = jwt.sign(buildAccessToken(user), config.tokenSecret, {
       algorithm: "ES512",

--- a/packages/backend/src/controllers/bo-user/create.js
+++ b/packages/backend/src/controllers/bo-user/create.js
@@ -7,6 +7,8 @@ const ValidationAppError = require("../../utils/validation-error");
 const MailUtils = require("../../utils/mail");
 const Send = require("../../services/mail").mailService.send;
 const { buildEmailToken } = require("../../utils/bo-token");
+const serviceCompetence = require("./service-competence");
+const verifyCompetence = require("./service-competence");
 
 const BOUserSchema = require("../../schemas/bo-user");
 const config = require("../../config");
@@ -25,30 +27,36 @@ module.exports = async function create(req, res, next) {
   } catch (error) {
     return next(new ValidationAppError(error));
   }
-
-  try {
-    await BoUser.create(user);
-
+  const serviceCompetentUserConnected = await serviceCompetence(req.decoded.territoireCode);
+  const serviceCompetentUtilisateurCreate = await serviceCompetence(user.territoireCode);
+  if (verifyCompetence(serviceCompetentUserConnected,serviceCompetentUtilisateurCreate))
+  {
     try {
-      const email = user.email;
-      const token = jwt.sign(buildEmailToken(email), config.tokenSecret, {
-        algorithm: "ES512",
-        expiresIn: config.validationToken.expiresIn / 1000,
-      });
+      await BoUser.create(user);
 
-      await Send(
-        MailUtils.bo.authentication.sendValidationMail({
-          email,
-          token,
-        }),
-      );
+      try {
+        const email = user.email;
+        const token = jwt.sign(buildEmailToken(email), config.tokenSecret, {
+          algorithm: "ES512",
+          expiresIn: config.validationToken.expiresIn / 1000,
+        });
+
+        await Send(
+          MailUtils.bo.authentication.sendValidationMail({
+            email,
+            token,
+          }),
+        );
+      } catch (error) {
+        log.w(error.name, error.message);
+      }
+
+      return res.status(200).json({ message: "Utilisateur créé" });
     } catch (error) {
-      log.w(error.name, error.message);
+      log.w("DONE with error");
+      return next(error);
     }
-
-    return res.status(200).json({ message: "Utilisateur créé" });
-  } catch (error) {
-    log.w("DONE with error");
-    return next(error);
   }
+  else
+    return res.status(403).json({ message: "Permission refusée. Privilèges insuffisants" });
 };

--- a/packages/backend/src/controllers/bo-user/index.js
+++ b/packages/backend/src/controllers/bo-user/index.js
@@ -3,3 +3,5 @@ module.exports.getOne = require("./get-one");
 module.exports.getMe = require("./get-me");
 module.exports.create = require("./create");
 module.exports.update = require("./update");
+module.exports.serviceCompetence = require("./service-competence");
+module.exports.verifyCompetence = require("./service-competence");

--- a/packages/backend/src/controllers/bo-user/service-competence.js
+++ b/packages/backend/src/controllers/bo-user/service-competence.js
@@ -1,0 +1,22 @@
+const logger = require("../../utils/logger");
+const { competence } = require("../../helpers/bo-competence")
+
+const log = logger(module.filename);
+
+module.exports = async function serviceCompetence(territoireCode) {
+  try {
+    log.i("IN"),territoireCode;
+    log.i("DONE");
+    return (territoireCode === "FRA") ? 'NAT' : (/^[0-9]+$/.test(territoireCode)) ? 'DEP' : 'REG';
+  } catch (error) {
+    log.w("DONE with error");
+    return error;
+  }
+};
+
+module.exports = async function verifyCompetence(serviceCompetentUserConnected,serviceCompetentUtilisateurCreateOrUpdate) {
+    return (serviceCompetentUserConnected === competence.NATIONALE || (serviceCompetentUtilisateurCreateOrUpdate != competence.NATIONALE && serviceCompetentUserConnected === competence.REGIONALE) || (serviceCompetentUtilisateurCreateOrUpdate === competence.DEPARTEMENTALE && serviceCompetentUserConnected === competence.DEPARTEMENTALE))
+  };
+  
+
+

--- a/packages/backend/src/helpers/bo-competence.js
+++ b/packages/backend/src/helpers/bo-competence.js
@@ -1,0 +1,6 @@
+module.exports.competence = {
+    NATIONALE: "NAT",
+    REGIONALE: "REG",
+    DEPARTEMENTALE: "DEP",
+  };
+  

--- a/packages/backend/src/routes/bo-user.js
+++ b/packages/backend/src/routes/bo-user.js
@@ -18,5 +18,7 @@ router.get("/:userId", BOcheckJWT, BOcheckRoleCompte, BOUserController.getOne);
 router.post("/", BOcheckJWT, BOcheckRoleCompte, BOUserController.create);
 // Mise à jour d'un utilisateur
 router.post("/:userId", BOcheckJWT, BOcheckRoleCompte, BOUserController.update);
+// Fonctione transverse de recherche du service compétent
+router.get("/:territoireCode", BOcheckJWT, BOcheckRoleCompte, BOUserController.serviceCompetence);
 
 module.exports = router;

--- a/packages/frontend-bo/src/pages/comptes/[[userId]].vue
+++ b/packages/frontend-bo/src/pages/comptes/[[userId]].vue
@@ -69,7 +69,6 @@
                   />
                 </div>
               </div>
-
               <div
                 class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
               >
@@ -88,24 +87,6 @@
                     @update:model-value="checkValidPrenom"
                   />
                 </div>
-              </div>
-
-              <div
-                class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
-              >
-                <DsfrCheckboxSet
-                  name="roleUtilisateurField"
-                  legend="Rôle(s) associé(s) à l'utilisateur ?"
-                  :required="true"
-                  :model-value="roleUtilisateurField.modelValue"
-                  :options="roleOptions"
-                  :is-valid="roleUtilisateurField.isValid"
-                  :inline="true"
-                  :error-message="
-                    roleUtilisateurField.roleUtilisateurErrorMessage
-                  "
-                  @update:model-value="checkValidRoleUtilisateur"
-                />
               </div>
               <div
                 class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
@@ -160,7 +141,23 @@
                   </div>
                 </fieldset>
               </div>
-
+              <div
+                class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
+              >
+                <DsfrCheckboxSet
+                  name="roleUtilisateurField"
+                  legend="Rôle(s) associé(s) à l'utilisateur ?"
+                  :required="true"
+                  :model-value="roleUtilisateurField.modelValue"
+                  :options="roleOptions"
+                  :is-valid="roleUtilisateurField.isValid"
+                  :inline="true"
+                  :error-message="
+                    roleUtilisateurField.roleUtilisateurErrorMessage
+                  "
+                  @update:model-value="checkValidRoleUtilisateur"
+                />
+              </div>
               <div
                 class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
               >
@@ -249,6 +246,7 @@ const formStates = {
 };
 
 let formStatus = ref(formStates.CREATION);
+let serviceCompetenceOptions = [];
 
 const emailField = reactive({
   errorMessage: "",
@@ -357,7 +355,7 @@ function checkValidServiceCompetence(p) {
   log.d("checkValidServiceCompetence : p = ", p);
   serviceCompetenceField.modelValue = p;
   serviceCompetenceField.isValid = p !== null;
-  if (serviceCompetenceField.isValid === true && p === "NAT")
+  if (serviceCompetenceField.isValid === true && p === competence.NATIONALE)
     territoireField.isValid = true;
   else territoireField.isValid = false;
   serviceCompetenceField.errorMessage =
@@ -370,11 +368,11 @@ function checkValidTerritoire(p) {
   territoireField.modelValue = p;
   territoireField.isValid = p !== null;
   territoireField.errorMessage =
-    !p || serviceCompetenceField.modelValue === "NAT"
+    !p || serviceCompetenceField.modelValue === competence.NATIONALE
       ? ""
-      : serviceCompetenceField.modelValue === "DEP"
+      : serviceCompetenceField.modelValue === competence.DEPARTEMENTALE
         ? "Le département du service doit obligatoirement être renseigné"
-        : serviceCompetenceField.modelValue === "REG"
+        : serviceCompetenceField.modelValue === competence.REGIONALE
           ? "La région du service doit obligatoirement être renseignée"
           : "";
 }
@@ -389,7 +387,7 @@ function checkValidRoleUtilisateur(p) {
 }
 
 watch([() => serviceCompetenceField.modelValue], function () {
-  if (serviceCompetenceField.modelValue === "NAT")
+  if (serviceCompetenceField.modelValue === competence.NATIONALE)
     territoireField.modelValue = "FRA";
   //    else
   //        territoireField.modelValue = null;
@@ -397,6 +395,13 @@ watch([() => serviceCompetenceField.modelValue], function () {
 
 onMounted(async () => {
   log.i("Mounted - IN");
+  serviceCompetenceOptions = [];
+  if (usersStore.user.serviceCompetent === competence.NATIONALE ) 
+    serviceCompetenceOptions.push(serviceCompetenceNAT);
+  if (usersStore.user.serviceCompetent === competence.NATIONALE || usersStore.user.serviceCompetent === competence.REGIONALE) 
+    serviceCompetenceOptions.push(serviceCompetenceREG);
+  serviceCompetenceOptions.push(serviceCompetenceDEP);
+
   // Mode Edition
   if (userId) {
     // Chargement des données utilisateur
@@ -414,11 +419,11 @@ onMounted(async () => {
     prenomField.isValid = true;
     // Sélection du service de compétence
     if (usersStore.userSelected.territoireCode === "FRA")
-      serviceCompetenceField.modelValue = "NAT";
+      serviceCompetenceField.modelValue = competence.NATIONALE;
     else if (usersStore.userSelected.territoireParent === "FRA") {
-      serviceCompetenceField.modelValue = "REG";
+      serviceCompetenceField.modelValue = competence.REGIONALE;
     } else {
-      serviceCompetenceField.modelValue = "DEP";
+      serviceCompetenceField.modelValue = competence.DEPARTEMENTALE;
     }
     serviceCompetenceField.isValid = true;
     territoireField.modelValue = usersStore.userSelected.territoireCode;

--- a/packages/frontend-bo/src/utils/serviceCompetenceOptions.js
+++ b/packages/frontend-bo/src/utils/serviceCompetenceOptions.js
@@ -1,14 +1,21 @@
-export const serviceCompetenceOptions = [
-  {
-    label: "Nationale",
-    value: "NAT",
-  },
-  {
-    label: "Régionale",
-    value: "REG",
-  },
-  {
-    label: "Départementale",
-    value: "DEP",
-  },
-];
+
+export const competence = {
+  NATIONALE: "NAT",
+  REGIONALE: "REG",
+  DEPARTEMENTALE: "DEP",
+};
+
+export const serviceCompetenceNAT = {
+  label: "Nationale",
+  value: competence.NATIONALE,
+};
+
+export const serviceCompetenceREG = {
+  label: "Régionale",
+  value: competence.REGIONALE,
+}
+
+export const serviceCompetenceDEP = {
+  label: "Départementale",
+  value: competence.DEPARTEMENTALE,
+}


### PR DESCRIPTION
Ticket #357
Restriction de la création des comptes en fonction de sa zone géographique
- Compétence NAT : Peut créer du NAT, REG et DEP
- Compétence REG : Peut créer du REG ou DEP
- Compétence DEP : Ne peut créer que du DEP

Implémentation frontend et backend

Déplacement ergonomique pour remonter la zone de compétence sur la création et mise à jour des comptes