### PR TITLE
fix(loginBO): Correction plantage backend avec Invalid salt

### DIFF
--- a/packages/backend/src/controllers/bo-authentication/email/login.js
+++ b/packages/backend/src/controllers/bo-authentication/email/login.js
@@ -26,62 +26,72 @@ module.exports = async function login(req, res, next) {
       }),
     );
   }
+  try {
+    const user = await User.login({ email, password });
 
-  const user = await User.login({ email, password });
-
-  if (!user) {
-    log.w("Utilisateur BO inexistant");
+    if (!user) {
+      log.w("Utilisateur BO inexistant");
+      return next(
+        new AppError("Mauvais identifiants", {
+          name: "WrongCredentials",
+          statusCode: 404,
+        }),
+      );
+    }
+  
+    log.d({ user });
+    if (user.statusCode === status.NEED_EMAIL_VALIDATION) {
+      log.w("Compte non validé");
+      return next(
+        new AppError("Compte non validé", {
+          name: "NotValidatedAccount",
+          statusCode: 400,
+        }),
+      );
+    }
+  
+    try {
+      const accessToken = jwt.sign(buildAccessToken(user), config.tokenSecret, {
+        algorithm: "ES512",
+        expiresIn: config.accessToken.expiresIn / 1000, // Le délai avant expiration exprimé en seconde
+      });
+  
+      const refreshToken = jwt.sign(buildRefreshToken(user), config.tokenSecret, {
+        algorithm: "ES512",
+        expiresIn: config.refreshToken.expiresIn / 1000,
+      });
+  
+      await Session.create(user.id, refreshToken);
+  
+      res.cookie("VAO_BO_access_token", accessToken, {
+        httpOnly: true,
+        maxAge: config.accessToken.expiresIn,
+        sameSite: "strict",
+        secure: true,
+      });
+  
+      res.cookie("VAO_BO_refresh_token", refreshToken, {
+        httpOnly: true,
+        maxAge: config.refreshToken.expiresIn,
+        sameSite: "strict",
+        secure: true,
+      });
+  
+      log.i("DONE");
+  
+      return res.json({ user });
+    } catch (error) {
+      log.w("DONE with error");
+      return next(error);
+    }    
+  } catch (error) {
+    log.w("DONE with error");
     return next(
-      new AppError("Mauvais identifiants", {
-        name: "WrongCredentials",
-        statusCode: 404,
-      }),
-    );
-  }
-
-  log.d({ user });
-  if (user.statusCode === status.NEED_EMAIL_VALIDATION) {
-    log.w("Compte non validé");
-    return next(
-      new AppError("Compte non validé", {
-        name: "NotValidatedAccount",
+      new AppError(error, {
+        name: "UnknownError",
         statusCode: 400,
       }),
     );
   }
 
-  try {
-    const accessToken = jwt.sign(buildAccessToken(user), config.tokenSecret, {
-      algorithm: "ES512",
-      expiresIn: config.accessToken.expiresIn / 1000, // Le délai avant expiration exprimé en seconde
-    });
-
-    const refreshToken = jwt.sign(buildRefreshToken(user), config.tokenSecret, {
-      algorithm: "ES512",
-      expiresIn: config.refreshToken.expiresIn / 1000,
-    });
-
-    await Session.create(user.id, refreshToken);
-
-    res.cookie("VAO_BO_access_token", accessToken, {
-      httpOnly: true,
-      maxAge: config.accessToken.expiresIn,
-      sameSite: "strict",
-      secure: true,
-    });
-
-    res.cookie("VAO_BO_refresh_token", refreshToken, {
-      httpOnly: true,
-      maxAge: config.refreshToken.expiresIn,
-      sameSite: "strict",
-      secure: true,
-    });
-
-    log.i("DONE");
-
-    return res.json({ user });
-  } catch (error) {
-    log.w("DONE with error");
-    return next(error);
-  }
 };

--- a/packages/frontend-bo/src/pages/connexion/index.vue
+++ b/packages/frontend-bo/src/pages/connexion/index.vue
@@ -211,6 +211,12 @@ const displayInfos = {
     description: "Votre email ou votre mot de passe sont incorrects.",
     type: "error",
   },
+  UnknownError: {
+    title: "Une erreur est survenue",
+    description:
+      "Une erreur inconnue est survenue. Veuillez contacter votre administrateur",
+    type: "error",
+  },
   UnexpectedError: {
     title: "Une erreur est survenue",
     description:
@@ -262,6 +268,9 @@ async function login() {
         break;
       case "NotValidatedAccount":
         displayType.value = "NotValidatedAccount";
+        break;
+      case "UnknownError":
+        displayType.value = "UnknownError";
         break;
       default:
         displayType.value = "UnexpectedError";


### PR DESCRIPTION
Interception de l'erreur Invalid Salt (renvoyé par la requête en BDD dont la source n'est pas identifiée)
Ajout d'un message "Erreur inconnue" 