### PR TITLE
fix(ds8j): prestaire-datenaiss-ascenseur-h-332

### DIFF
--- a/packages/frontend-usagers/src/components/DS/prestataires.vue
+++ b/packages/frontend-usagers/src/components/DS/prestataires.vue
@@ -90,7 +90,12 @@ const headers = [
   {
     column: "dateNaissance",
     sorter: "dateNaissance",
-    format: (value) => dayjs(value.dateNaissance).format("DD/MM/YYYY"),
+    format: (value) => {
+      if (value.typePrestataire === "personne_morale") {
+        return null;
+      }
+      return dayjs(value.dateNaissance).format("DD/MM/YYYY");
+    },
     text: "Date de naissance",
 
     headerAttrs: {

--- a/packages/frontend-usagers/src/components/utils/TableFull.vue
+++ b/packages/frontend-usagers/src/components/utils/TableFull.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="margin-bottom: 1em">
+  <div style="margin-bottom: 2em; overflow-x: auto">
     <div v-if="displayedData.length">
       <DsfrTable
         style="display: table"


### PR DESCRIPTION
Pour les prestaires de restauration : 
Mise à blanc de la date de naissance pour les types “personne morale”

Transverse : 
Ajout d’un ascenseur horizontal (transverse à tous les tableaux) en cas de dépassement de la largeur max des colonnes (texte long sans espace)