### PR TITLE
fix(AR-2M-8J): génération des AR uniquement à la validation #vao-418

### DIFF
--- a/packages/backend/src/controllers/demandeSejour/depose.js
+++ b/packages/backend/src/controllers/demandeSejour/depose.js
@@ -205,12 +205,6 @@ module.exports = async function post(req, res, next) {
         declaration.idFonctionnelle,
         declaration.departementSuivi,
       );
-
-      ARuuid = await ARDeclaration8jours(
-        declaration,
-        declaration.idFonctionnelle,
-        declaration.departementSuivi,
-      );
     } catch (error) {
       log.w(error);
     }

--- a/packages/backend/src/controllers/demandeSejour/enregistrementDemande2Mois.js
+++ b/packages/backend/src/controllers/demandeSejour/enregistrementDemande2Mois.js
@@ -1,5 +1,6 @@
 const DemandeSejour = require("../../services/DemandeSejour");
 const PdfARDeclaration2Mois = require("../../services/pdf/ARdeclaration2mois/generate");
+const PdfARDeclaration8Jours = require("../../services/pdf/ARdeclaration8jours/generate");
 
 const logger = require("../../utils/logger");
 const { statuts } = require("../../helpers/ds-statuts");
@@ -48,20 +49,28 @@ module.exports = async function post(req, res, next) {
     );
   }
 
-  if (declaration.statut !== statuts.EN_COURS && declaration.statut !== statuts.EN_COURS_8J) {
+  if (
+    declaration.statut !== statuts.EN_COURS &&
+    declaration.statut !== statuts.EN_COURS_8J
+  ) {
     return next(
       new AppError("Statut incompatible", {
         statusCode: 400,
       }),
     );
   }
-  const enCoursTypeStatut = declaration.statut === statuts.EN_COURS ? statuts.ATTENTE_8_JOUR : statuts.VALIDEE_8J;
-  const textTypePrecision = "Enregistrement de la déclaration à " + (declaration.statut === statuts.EN_COURS ? " 2 mois" : " 8 jours");
-
+  const enCoursTypeStatut =
+    declaration.statut === statuts.EN_COURS
+      ? statuts.ATTENTE_8_JOUR
+      : statuts.VALIDEE_8J;
+  const textTypePrecision =
+    "Enregistrement de la déclaration à " +
+    (declaration.statut === statuts.EN_COURS ? " 2 mois" : " 8 jours");
 
   try {
-    if (declaration.statut !== statuts.EN_COURS)
+    if (declaration.statut === statuts.EN_COURS)
       await PdfARDeclaration2Mois(declaration);
+    else await PdfARDeclaration8Jours(declaration);
 
     const destinataires = await DemandeSejour.getEmailToList(
       declaration.organismeId,

--- a/packages/backend/src/services/pdf/ARdeclaration8jours/generate.js
+++ b/packages/backend/src/services/pdf/ARdeclaration8jours/generate.js
@@ -15,7 +15,7 @@ const generate = async (declaration) => {
 
     // insert into documents table
     const uuid = await Document.createFile(
-      `AR_${declaration.idFonctionnelle}.pdf`,
+      `AR_${declaration.idFonctionnelle}_8J.pdf`,
       "AR_declaration_8_jours",
       "application/pdf",
       buffer,
@@ -34,7 +34,7 @@ const generate = async (declaration) => {
     const files = declaration.files.files;
     const fileToAdd = {
       createdAt: dayjs().format(),
-      name: `AR_${declaration.idFonctionnelle}.pdf`,
+      name: `AR_${declaration.idFonctionnelle}_8J.pdf`,
       type: "AR_declaration_8_jours",
       uuid,
     };


### PR DESCRIPTION
- Génération des AR uniquement à la validation par le service de la déclaration #vao-418
- Ajout de _8J dans le nom du fichier pour les AR 8J pour avoir des noms uniques 2M et 8J
- Suppression de la génération de l'AR 8J à la dépose. 