### PR TITLE
feat(BO-auth): possibilite de regenerer un token

### DIFF
--- a/packages/backend/src/config.js
+++ b/packages/backend/src/config.js
@@ -66,7 +66,7 @@ module.exports = {
   tmpDirectory: process.env.TMP_DIRECTORY,
   tokenSecret: process.env.TOKEN_SECRET,
   validationToken: {
-    expiresIn: 30 * 60 * 1000, // 30 min
+    expiresIn: 60 * 60 * 1000, // 30 min
     secret: process.env.VALIDATION_TOKEN_SECRET,
   },
 };

--- a/packages/backend/src/utils/mail.js
+++ b/packages/backend/src/utils/mail.js
@@ -89,6 +89,7 @@ module.exports = {
                 "Bonjour,",
                 "Vous recevez ce mail car vous vous avez été inscrit sur le portail VAO Administration.",
                 "Pour activer votre compte et créer votre mot de passe, veuillez cliquer sur lien ci dessous.",
+                "Attention, ce lien n’est valable qu’une heure. Si celui-ci est expiré, vous pouvez en générer un nouveau en suivant le lien d’activation",
               ],
               type: "p",
             },
@@ -329,7 +330,7 @@ module.exports = {
           from: senderEmail,
           html: `
           <p>Bonjour,</p>
-          <p>Vous êtes titulaire de l’agrément « Vacances adaptées organisées » délivré le ${dayjs(declaration.organisme.agrement.dateObtention).format("DD/MM/YYYY")} et avez déposé en date du   
+          <p>Vous êtes titulaire de l’agrément « Vacances adaptées organisées » délivré le ${dayjs(declaration.organisme.agrement.dateObtention).format("DD/MM/YYYY")} et avez déposé en date du
           ${dayjs(declaration.attestation.at).format("DD/MM/YYYY")}, une déclaration pour le séjour « ${declaration.libelle} » que vous organisez du ${dayjs(declaration.dateDebut).format("DD/MM/YYYY")} au ${dayjs(declaration.dateFin).format("DD/MM/YYYY")}.</p>
           <p>Nous accusons ce jour, le ${dayjs().format("DD/MM/YYYY")}, réception de votre déclaration ${declaration.idFonctionnelle}.</p>
           <p>Vous devrez, huit jours avant le déroulement de ce séjour, réaliser la déclaration complémentaire prévue à l’article R. 412-14 du code du tourisme.</p>

--- a/packages/frontend-bo/src/components/connexion/email/validateToken.client.vue
+++ b/packages/frontend-bo/src/components/connexion/email/validateToken.client.vue
@@ -42,17 +42,16 @@ const { data, error, pending } = useFetchBackend(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ token: props.token }),
+
+    onResponseError({ response }) {
+      if (response._data?.name) {
+        const codeError = response._data.name;
+        log.w({ codeError });
+        classError.value = codeError;
+      }
+    },
   },
 );
-
-watch(error, () => {
-  if (error.value == null) {
-    return;
-  }
-  log.w({ error });
-  const codeError = error.value.data.name;
-  classError.value = codeError;
-});
 
 watch(data, () => {
   if (data.value == null) {


### PR DESCRIPTION
close jira 379 (https://jira-mcas.atlassian.net/browse/VAO-379?atlOrigin=eyJpIjoiZjRmMzdkZGE0YzUwNDA5MDhjZTRjMTI1M2I5YmQxYzAiLCJwIjoiaiJ9).

La logique de regénération du token existait deja, mais ne fonctionnait pas : 
Le watch du composant `validate-token`n'était pas trigger avec les erreurs pour un raison inconnue. Surement un probleme avec nuxt au mount du composant. j'ai changé et utilisé les callbacks de usefetch pour arriver au meme principe.

https://www.loom.com/share/09db286d1d284046978aba0059c3aae3?sid=4eb1c989-d834-457d-a206-dadda53cd2b4