### PR TITLE
feat(declaration_sejour): annulation d'une DS #367 #452 #453 #454

### DIFF
--- a/packages/backend/src/controllers/demandeSejour/cancel.js
+++ b/packages/backend/src/controllers/demandeSejour/cancel.js
@@ -91,17 +91,18 @@ module.exports = async function cancel(req, res, next) {
       const departements = declaration.hebergement.hebergements.map(
         (h) => h.coordonnees.adresse.departement,
       );
-
-      await Send(
-        MailUtils.bo.declarationSejour.sendDeclarationCanceled({
-          declaration,
-          departementSuivi: declaration.departementSuivi,
-          departementsSecondaires: departements.filter(
-            (d) => d !== declaration.departementSuivi,
-          ),
-          destinataires: destinatairesBack,
-        }),
-      );
+      if (destinatairesBack.length>0) {
+        await Send(
+          MailUtils.bo.declarationSejour.sendDeclarationCanceled({
+            declaration,
+            departementSuivi: declaration.departementSuivi,
+            departementsSecondaires: departements.filter(
+              (d) => d !== declaration.departementSuivi,
+            ),
+            destinataires: destinatairesBack,
+          }),
+        );
+      }
 
     }
   } catch (error) {

--- a/packages/backend/src/controllers/demandeSejour/cancel.js
+++ b/packages/backend/src/controllers/demandeSejour/cancel.js
@@ -1,0 +1,137 @@
+const { statuts } = require("../../helpers/ds-statuts");
+const DemandeSejour = require("../../services/DemandeSejour");
+const Send = require("../../services/mail").mailService.send;
+const MailUtils = require("../../utils/mail");
+const logger = require("../../utils/logger");
+const AppError = require("../../utils/error");
+
+const log = logger(module.filename);
+
+module.exports = async function cancel(req, res, next) {
+  const demandeSejourId = req.params.id;
+  const { id: userId } = req.decoded;
+
+  log.i("IN", { demandeSejourId });
+  let declaration
+  let canceletedRows
+  try {
+    declaration = await DemandeSejour.getOne({
+      "ds.id": demandeSejourId,
+    });
+
+    if (!declaration) {
+      log.w("DONE with error");
+      return next(
+        new AppError("Déclaration non trouvée", {
+          statusCode: 404,
+        }),
+      );
+    }
+    log.i(declaration.statut);
+    const statutsCancellable = [
+      statuts.TRANSMISE,
+      statuts.EN_COURS,
+      statuts.A_MODIFIER,
+      statuts.ATTENTE_8_JOUR,
+      statuts.TRANSMISE_8J,
+      statuts.EN_COURS_8J,
+      statuts.A_MODIFIER_8J
+    ];
+    
+    if (!statutsCancellable.includes(declaration.statut)) { 
+        log.w("DONE with error");
+        return next(
+          new AppError(
+            "Impossible d'annuler une demande qui n'est pas au bon statut",
+            {
+              statusCode: 400,
+            },
+          ),
+        );
+      }
+      canceletedRows = await DemandeSejour.cancel(declaration.id, userId);
+      if (canceletedRows !== 1) {
+        log.w(`DONE with error, ${canceletedRows} rows were updated, expected one `);
+        return next(
+          new AppError(
+            "Erreur de l'annulation, trop de lignes mises à jour ou pas assez",
+            {
+              statusCode: 400,
+            },
+          ),
+        );
+      }
+      else
+      {
+        await DemandeSejour.insertEvent(
+          "Organisateur",
+          declaration.id,
+          userId,
+          null,
+          "declaration_sejour",
+          "Annulation de la déclaration",
+          declaration,
+        );
+      }
+
+  } catch (err) {
+    log.w(err);
+    return next(
+      new AppError("Erreur de l'annulation de la demande de sejour", {
+        statusCode: 400,
+      }),
+    );
+  }
+  try {
+    const destinatairesBack = await DemandeSejour.getEmailBack(
+      declaration.departementSuivi,
+    );
+
+    if (destinatairesBack) {
+      const departements = declaration.hebergement.hebergements.map(
+        (h) => h.coordonnees.adresse.departement,
+      );
+
+      await Send(
+        MailUtils.bo.declarationSejour.sendDeclarationCanceled({
+          declaration,
+          departementSuivi: declaration.departementSuivi,
+          departementsSecondaires: departements.filter(
+            (d) => d !== declaration.departementSuivi,
+          ),
+          destinataires: destinatairesBack,
+        }),
+      );
+
+    }
+  } catch (error) {
+    log.w(error);
+    return next(
+      new AppError(
+        "Une erreur est survenue lors de l'envoi de mails aux usagers back office",
+        {
+          statusCode: 500,
+        },
+      ),
+    );
+  }
+
+  try {
+    const destinataires = await DemandeSejour.getEmailToList(
+      declaration.organismeId,
+    );
+
+    await Send(
+      MailUtils.usagers.declarationSejour.sendCanceledMail({
+        declaration,
+        destinataires,
+      }),
+    );
+
+    log.i("DONE");
+    return res.status(200).json({ canceletedRows });
+  } catch (error) {
+    log.w("DONE with error");
+    return next(error);
+  }  
+};

--- a/packages/backend/src/controllers/demandeSejour/copy.js
+++ b/packages/backend/src/controllers/demandeSejour/copy.js
@@ -34,7 +34,8 @@ module.exports = async function post(req, res, next) {
     if (
       sourceDeclaration.statut !== statuts.BROUILLON &&
       sourceDeclaration.statut !== statuts.TRANSMISE &&
-      sourceDeclaration.statut !== statuts.EN_COURS
+      sourceDeclaration.statut !== statuts.EN_COURS && 
+      sourceDeclaration.statut !== statuts.ANNULEE
     ) {
       log.w("DONE with error");
       return next(

--- a/packages/backend/src/controllers/demandeSejour/index.js
+++ b/packages/backend/src/controllers/demandeSejour/index.js
@@ -13,3 +13,4 @@ module.exports.refus = require("./refus");
 module.exports.enregistrementDemande2Mois = require("./enregistrementDemande2Mois");
 module.exports.copy = require("./copy");
 module.exports.delete = require("./delete");
+module.exports.cancel = require("./cancel");

--- a/packages/backend/src/helpers/ds-statuts.js
+++ b/packages/backend/src/helpers/ds-statuts.js
@@ -10,4 +10,5 @@ module.exports.statuts = {
   TRANSMISE: "TRANSMISE",
   TRANSMISE_8J: "TRANSMISE 8J",
   VALIDEE_8J: "VALIDEE 8J",
+  ANNULEE: "ANNULEE",
 };

--- a/packages/backend/src/routes/sejour.js
+++ b/packages/backend/src/routes/sejour.js
@@ -73,4 +73,5 @@ router.post("/:id/copy", checkJWT, demandeSejourController.copy);
 router.post("/:id", checkJWT, canUpdateDs, demandeSejourController.update);
 router.post("/", checkJWT, demandeSejourController.post);
 router.delete("/:id", checkJWT, demandeSejourController.delete);
+router.post("/cancel/:id", checkJWT, demandeSejourController.cancel);
 module.exports = router;

--- a/packages/backend/src/services/DemandeSejour.js
+++ b/packages/backend/src/services/DemandeSejour.js
@@ -140,6 +140,19 @@ const query = {
     ;`,
     [declarationId, userId],
   ],
+  cancel: (declarationId, userId) => [
+    `
+    UPDATE front.demande_sejour d
+    SET statut = 'ANNULEE' 
+    FROM front.organismes o, front.user_organisme uo
+    WHERE 
+      o.id = d.organisme_id 
+      AND uo.org_id = o.id
+      AND d.id = $1
+      AND uo.use_id = $2;
+    ;`,
+    [declarationId, userId],
+  ],
   finalize: (
     demandeSejourId,
     idFonctionnelle,
@@ -666,6 +679,12 @@ module.exports.delete = async (declarationId, userId) => {
   log.i("delete - IN");
   const { rowCount } = await pool.query(...query.delete(declarationId, userId));
   log.i("delete - DONE");
+  return rowCount;
+};
+module.exports.cancel = async (declarationId, userId) => {
+  log.i("cancel - IN");
+  const { rowCount } = await pool.query(...query.cancel(declarationId, userId));
+  log.i("cancel - DONE");
   return rowCount;
 };
 module.exports.get = async (organismesId) => {

--- a/packages/backend/src/utils/mail.js
+++ b/packages/backend/src/utils/mail.js
@@ -116,6 +116,38 @@ module.exports = {
       },
     },
     declarationSejour: {
+      sendDeclarationCanceled: ({
+        declaration,
+        destinataires,
+      }) => {
+        log.i("sendDeclarationCanceled - In", {
+          destinataires,
+        });
+        if (!destinataires) {
+          const message = `Le paramètre destinataires manque à la requête`;
+          log.w(`sendDeclarationCanceled - ${message}`);
+          throw new AppError(message);
+        }
+
+        const params = {
+          from: senderEmail,
+          html: `
+                <p>Bonjour,</p><br>
+                <p>La déclaration ${declaration.idFonctionnelle}, «${declaration.libelle}», vient d'être annulée par l'organisateur sur le portail VAO</p>
+                <p>Il n'y a plus aucune action à effectuer dessus.</p><br>
+                <p>Cordialement,</p><br>
+                <p>L'équipe du SI VAO</p>
+                `,
+          replyTo: senderEmail,
+          subject: `Portail VAO - Déclaration annulée : ${declaration.idFonctionnelle}`,
+          to: destinataires,
+        };
+        log.d("sendDeclarationCanceled post email", {
+          params,
+        });
+
+        return params;
+      },            
       sendDeclarationA8joursNotify: ({
         declaration,
         destinataires,
@@ -470,6 +502,35 @@ module.exports = {
           to: destinataires,
         };
         log.d("sendRefusMail post email", {
+          params,
+        });
+
+        return params;
+      },
+      sendCanceledMail: ({ destinataires, declaration }) => {
+        log.i("sendCanceledMail - In", {
+          destinataires,
+        });
+        if (!destinataires) {
+          const message = `Le paramètre destinataires manque à la requête`;
+          log.w(`sendCanceledMail - ${message}`);
+          throw new AppError(message);
+        }
+
+        const params = {
+          from: senderEmail,
+          html: `
+                <p>Bonjour,</p><br>
+                <p>Votre déclaration ${declaration.idFonctionnelle} a bien été annulée à votre demande.</p>
+                <p>Les services compétents ont été avisés de cette annulation.</p><br>
+                <p>Cordialement,</p><br>
+                <p>L'équipe VAO</p>
+                `,
+          replyTo: senderEmail,
+          subject: `Portail VAO - Déclaration annulée : ${declaration.idFonctionnelle}`,
+          to: destinataires,
+        };
+        log.d("sendCanceledMail post email", {
           params,
         });
 

--- a/packages/frontend-bo/src/utils/demandes-sejours.js
+++ b/packages/frontend-bo/src/utils/demandes-sejours.js
@@ -15,6 +15,7 @@ const statuts = {
   VALIDEE_8J: "VALIDEE 8J",
   REFUSEE: "REFUSEE",
   REFUSEE_8J: "REFUSEE 8J",
+  ANNULEE: "ANNULEE",
 };
 
 const getSaison = (demande) => {

--- a/packages/frontend-usagers/src/pages/demande-sejour/liste.vue
+++ b/packages/frontend-usagers/src/pages/demande-sejour/liste.vue
@@ -454,7 +454,7 @@ const headers = [
             icon: row.statut === DeclarationSejour.statuts.BROUILLON ? "ri-delete-bin-2-line" : "ri-close-line",
             onClick: (event) => {
               event.stopPropagation();
-              deleteOrCancelDS(row.demandeSejourId,row.statut);
+              row.statut === DeclarationSejour.statuts.BROUILLON ? deleteDS(row.demandeSejourId) : cancelDS(row.demandeSejourId);
             },
             disabled: !(listeStatutAutoriseBoutonDeleteCancel.includes(row.statut)),
           },
@@ -486,12 +486,6 @@ async function copyDS(dsId) {
       `Une erreur est survenue lors de la copie de la déclaration de séjour`,
     );
   }
-}
-async function deleteOrCancelDS(dsId, statut) {
-  if (statut === DeclarationSejour.statuts.BROUILLON)
-    deleteDS(dsId);
-  else
-    cancelDS(dsId);
 }
 async function deleteDS(dsId) {
   log.i("deleteDS -IN");

--- a/packages/frontend-usagers/src/plugins/vue-dsfr.js
+++ b/packages/frontend-usagers/src/plugins/vue-dsfr.js
@@ -6,6 +6,7 @@ import {
   RiEyeCloseLine,
   RiDeleteBin2Line,
   RiFileCopy2Fill,
+  RiCloseLine,
 } from "oh-vue-icons/icons";
 
 import VueDsfr from "@gouvminint/vue-dsfr";
@@ -19,6 +20,7 @@ const icons = [
   RiDeleteBin2Line,
   RiQuestionLine,
   RiFileCopy2Fill,
+  RiCloseLine,
 ];
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueDsfr, { icons });

--- a/packages/frontend-usagers/src/utils/DeclarationSejour.js
+++ b/packages/frontend-usagers/src/utils/DeclarationSejour.js
@@ -24,6 +24,7 @@ const statuts = {
   A_MODIFIER_8J: "A MODIFIER 8J",
   VALIDEE_8J: "VALIDEE 8J",
   REFUSEE_8J: "REFUSEE 8J",
+  ANNULEE: "ANNULEE",
 };
 
 const log = logger("utils/DeclarationSejour");

--- a/packages/migrations/src/migrations/20240701170532_both__add_enum__annule.js
+++ b/packages/migrations/src/migrations/20240701170532_both__add_enum__annule.js
@@ -1,0 +1,31 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.raw(`
+    ALTER TYPE sejour_status ADD VALUE 'ANNULEE';
+  `);
+  };
+  
+  /**
+   * @param { import("knex").Knex } knex
+   * @returns { Promise<void> }
+   */
+  exports.down = function () {
+    return knex.raw(`
+    DELETE FROM pg_enum 
+    WHERE enumtypid = (SELECT e.enumtypid FROM pg_type t  
+      JOIN pg_enum e ON e.enumtypid = t.oid
+      WHERE t.typtype = 'e'
+      AND t.typname = 'sejour_status'
+      AND e.enumlabel = 'ANNULEE')
+    AND enumsortorder = (SELECT e.enumsortorder FROM pg_type t  
+      JOIN pg_enum e ON e.enumtypid = t.oid
+      WHERE t.typtype = 'e'
+      AND t.typname = 'sejour_status'
+      AND e.enumlabel = 'ANNULEE');
+      `);
+  }
+  ;
+  


### PR DESCRIPTION
Ajout fonctionnalité d'annulation d'une DS
BACK 
- Ajout du statut "ANNULEE"
FRONT USAGER (Liste des déclarations)
- Ajout d'un bouton pour annuler une DS (mutualisé avec le bouton de suppression) sur la liste des déclarations
- Ajout du statut "ANNULEE" dans les filtres de la liste des déclarations
- Envoie de mail à la DDETS
- Envoie de mail à l'organisateur
FRONT BO  (Liste des déclarations)
- Ajout du statut "ANNULEE" dans les filtres de la liste des demandes