### PR TITLE
feat(users-BO): desactivation compte users BO #342

### DIFF
--- a/packages/backend/src/controllers/bo-authentication/email/forgotten-password.js
+++ b/packages/backend/src/controllers/bo-authentication/email/forgotten-password.js
@@ -37,17 +37,18 @@ module.exports = async function forgottenPassword(req, res, next) {
   log.d({ user });
 
   try {
-    const token = jwt.sign(buildEmailToken(email), config.tokenSecret, {
-      algorithm: "ES512",
-      expiresIn: config.resetPasswordToken.expiresIn / 1000,
-    });
-    await Send(
-      MailUtils.bo.authentication.sendForgottenPassword({
-        email,
-        token,
-      }),
-    );
-
+    if (!user.deleted) {
+      const token = jwt.sign(buildEmailToken(email), config.tokenSecret, {
+        algorithm: "ES512",
+        expiresIn: config.resetPasswordToken.expiresIn / 1000,
+      });
+      await Send(
+        MailUtils.bo.authentication.sendForgottenPassword({
+          email,
+          token,
+        }),
+      );
+    }
     log.i("DONE");
 
     return res.json({ message: "Mail envoyé" });

--- a/packages/backend/src/controllers/bo-user/update.js
+++ b/packages/backend/src/controllers/bo-user/update.js
@@ -28,7 +28,7 @@ module.exports = async function update(req, res, next) {
   if (verifyCompetence(serviceCompetentUserConnected,serviceCompetentUtilisateurUpdate))
   {
     try {
-      await BoUser.update(userId, user);
+      await BoUser.update(userId, user, req.decoded.id);
       return res.status(200).json({ message: "Utilisateur mis à jour" });
     } catch (error) {
       log.w("DONE with error");

--- a/packages/backend/src/schemas/bo-user.js
+++ b/packages/backend/src/schemas/bo-user.js
@@ -1,4 +1,4 @@
-const { string, object, array } = require("yup");
+const { string, object, array, boolean } = require("yup");
 
 const emailSchema = require("./parts/email");
 const nomSchema = require("./parts/nom");
@@ -11,6 +11,7 @@ const schema = () =>
     prenom: prenomSchema(),
     roles: array().required(),
     territoireCode: string().required(),
+    deleted: boolean().required(),
   });
 
 module.exports = schema;

--- a/packages/backend/src/services/BoUser.js
+++ b/packages/backend/src/services/BoUser.js
@@ -365,10 +365,13 @@ module.exports.read = async (
     searchQuery += `   AND ter.label ilike $${searchParams.length + 1}\n`;
     searchParams.push(`%${search.territoire}%`);
   }
-
   if (search?.valide !== undefined) {
     searchQuery += `   AND us.validated = $${searchParams.length + 1}\n`;
     searchParams.push(`${search.valide === true || search.valide === "true"}`);
+  }
+  if (search?.actif !== undefined) {
+    searchQuery += `   AND us.deleted = not $${searchParams.length + 1}\n`;
+    searchParams.push(`${search.actif === true || search.actif === "true"}`);
   }
 
   let additionalQueryParts = "";

--- a/packages/backend/src/services/BoUser.js
+++ b/packages/backend/src/services/BoUser.js
@@ -68,6 +68,7 @@ const query = {
         edited_at = NOW()
       WHERE
         mail = $1
+        and deleted = false
       `,
     [normalize(email), password],
   ],
@@ -92,6 +93,8 @@ const query = {
       us.nom AS nom,
       us.prenom AS prenom,
       us.validated AS validated,
+      us.deleted AS deleted,
+      us.deleted_date as deleted_date,
       ter.label AS "territoire",
       us.ter_code AS "territoireCode",
       ter.parent_code AS "territoireParent",
@@ -171,11 +174,34 @@ ${additionalParamsQuery}
       SET
         nom = $2,
         prenom = $3,
-        ter_code = $4
+        ter_code = $4,
+        deleted = false
       WHERE
         id = $1
       `,
     [id, nom, prenom, territoireCode],
+  ],
+  delete: (id,deleted_use_id)=> [
+    `
+      UPDATE back.users
+      SET
+        deleted = true,
+        deleted_use_id = $2,
+        deleted_date = now()
+      WHERE
+        id = $1
+      `,
+    [id, deleted_use_id],
+  ],
+  undelete: (id)=> [
+    `
+      UPDATE back.users
+      SET
+        deleted = false
+      WHERE
+        id = $1
+      `,
+    [id],
   ],
 };
 
@@ -188,7 +214,7 @@ module.exports.create = async ({
 }) => {
   log.i("create - IN", { email });
 
-  // Test de l'existance d'un compte avec la même adresse mail
+  // Test de l'existance d'un compte avec la même adresse mail non désactivé
   const response = await pool.query(
     ...query.get({ "us.mail": normalize(email) }),
   );
@@ -216,32 +242,37 @@ module.exports.create = async ({
   return { code: "CreationCompte", user };
 };
 
-module.exports.update = async (id, { nom, prenom, roles, territoireCode }) => {
+module.exports.update = async (id, { nom, prenom, roles, territoireCode, deleted },deleted_use_id) => {
   log.i("update - IN", { id });
-
+  console.log("roles",roles);
+  console.log("id",id);
   if (!id) {
     throw new AppError("Paramètre manquant", {
       statusCode: 500,
     });
   }
-
   // Mise à jour du compte en base de données
   const { rowCount } = await pool.query(
     ...query.update(id, nom, prenom, territoireCode),
   );
-
+  
   if (rowCount === 0) {
     log.d("update - DONE - Utilisateur BO inexistant");
     throw new AppError("Utilisateur déjà inexistant", {
       name: "UserNotFound",
     });
   }
+console.log("userAction",deleted_use_id);
+  // Suppression logique du compte
+  if (deleted) 
+    await pool.query(...query.delete(id, deleted_use_id));
 
   // Suppression des roles de l'utilisateur
   await pool.query(...query.deleteRole(id));
 
   // Création des rôles en base de données
   for (const role of roles) {
+    console.log ("role: ", role)
     await pool.query(...query.bindRole(id, role));
   }
 

--- a/packages/backend/src/services/BoUser.js
+++ b/packages/backend/src/services/BoUser.js
@@ -244,8 +244,6 @@ module.exports.create = async ({
 
 module.exports.update = async (id, { nom, prenom, roles, territoireCode, deleted },deleted_use_id) => {
   log.i("update - IN", { id });
-  console.log("roles",roles);
-  console.log("id",id);
   if (!id) {
     throw new AppError("Paramètre manquant", {
       statusCode: 500,
@@ -262,7 +260,6 @@ module.exports.update = async (id, { nom, prenom, roles, territoireCode, deleted
       name: "UserNotFound",
     });
   }
-console.log("userAction",deleted_use_id);
   // Suppression logique du compte
   if (deleted) 
     await pool.query(...query.delete(id, deleted_use_id));
@@ -272,7 +269,6 @@ console.log("userAction",deleted_use_id);
 
   // Création des rôles en base de données
   for (const role of roles) {
-    console.log ("role: ", role)
     await pool.query(...query.bindRole(id, role));
   }
 

--- a/packages/backend/src/services/DemandeSejour.js
+++ b/packages/backend/src/services/DemandeSejour.js
@@ -449,7 +449,7 @@ SELECT
   h.id as "historiqueId",
   h.source as "source",
   h.demande_sejour_id as "declarationId",
-  CASE WHEN u.id IS NOT null then u.mail ELSE bu.mail END as "userEmail",
+  CASE WHEN u.id IS NOT null then u.mail ELSE bu.mail || replace(replace(bu.deleted::text,'true',' (inactif)'),'false','') END as "userEmail",
   h.bo_user_id as "userAdminId",
   h.type as "type",
   h.type_precision as "typePrecision",

--- a/packages/frontend-bo/src/composables/useMenuNavItem.js
+++ b/packages/frontend-bo/src/composables/useMenuNavItem.js
@@ -13,11 +13,11 @@ export const useMenuNavItems = () => {
             title: "Comptes",
             links: [
               {
-                text: "back office",
+                text: "Back-office",
                 to: "/comptes/liste",
               },
               {
-                text: "organismes",
+                text: "Organismes",
                 to: "/comptes/liste-organisme",
               },
             ],
@@ -28,7 +28,7 @@ export const useMenuNavItems = () => {
             title: "Comptes",
             links: [
               {
-                text: "organismes",
+                text: "Organismes",
                 to: "/comptes/liste-organisme",
               },
             ],

--- a/packages/frontend-bo/src/pages/comptes/[[userId]].vue
+++ b/packages/frontend-bo/src/pages/comptes/[[userId]].vue
@@ -191,7 +191,7 @@
                       >Compte actif</label
                     ><div v-if="!actifField.modelValue"><br>Désactivé le {{ formatDate(usersStore.userSelected.deleted_date, "dd/MM/yyyy") }}</div>
                     <p id="toggle-valide" class="fr-hint-text" v-if="usersStore.user.roles.includes('Desactivation')">
-                      <br>Désactivation du compte
+                      <br>Compte actif
                     </p>
                   </div>
                   <DsfrButton :disabled="!canSubmit" @click.prevent="update"

--- a/packages/frontend-bo/src/pages/comptes/[[userId]].vue
+++ b/packages/frontend-bo/src/pages/comptes/[[userId]].vue
@@ -515,7 +515,6 @@ onMounted(async () => {
     });
     // Suppression du rôle "Autorisé à désactiver les comptes" si l'a pas le droit lui même de le faire
     if (!usersStore.user.roles.includes('Desactivation')) {
-      console.log("Suppression du role de désactivation des roles")
       roleOptions.pop();
     }
     roleUtilisateurField.isValid = true;

--- a/packages/frontend-bo/src/pages/comptes/liste.vue
+++ b/packages/frontend-bo/src/pages/comptes/liste.vue
@@ -64,6 +64,8 @@
                 />
               </div>
             </div>
+          </fieldset>
+          <fieldset class="fr-fieldset">
             <div class="fr-toggle">
               <input
                 id="toggle-valide"
@@ -82,7 +84,27 @@
               <p id="toggle-valide" class="fr-hint-text">
                 Compte validé par courriel
               </p>
+            </div>            
+            <div class="fr-toggle">
+              <input
+                id="toggle-actif"
+                v-model="searchState.actif"
+                type="checkbox"
+                class="fr-toggle__input"
+                aria-describedby="toggle-actif"
+              />
+              <label
+                class="fr-toggle__label"
+                for="toggle-actif"
+                data-fr-checked-label="Activé"
+                data-fr-unchecked-label="Désactivé"
+                >Compte actif</label
+              >
+              <p id="toggle-actif" class="fr-hint-text">
+                Compte actif
+              </p>
             </div>
+
           </fieldset>
           <!--<DsfrButton @click.prevent="test">Test</DsfrButton
             >
@@ -127,6 +149,7 @@ const searchState = reactive({
   territoire: null,
   valide: true,
   email: null,
+  actif: true,
 });
 
 // Appel du store à l'ouverture

--- a/packages/migrations/src/migrations/20240711144251_back.roles__insert_desactivation.js
+++ b/packages/migrations/src/migrations/20240711144251_back.roles__insert_desactivation.js
@@ -1,0 +1,61 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+exports.up = function (knex) {
+  return knex
+    .withSchema("back")
+    .table("roles")
+    .insert({
+      id: 6,
+      label: "Desactivation",
+    })
+    .then(function () {
+      return knex.schema
+        .withSchema("back")
+        .table("users", function (table) {
+          table.integer("deleted_use_id");
+          table.datetime("deleted_date");
+        });
+    })
+    .then(function () {
+      return knex.raw("INSERT INTO back.user_roles SELECT id,6 FROM back.users where ter_code = 'FRA'")
+    })
+    .then(function () {
+      return knex.raw("UPDATE back.users SET deleted = false")
+    })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+/*
+DELETE FROM back.user_roles WHERE rol_id= 6
+DELETE FROM back.roles WHERE id= 6
+alter table back.users drop column deleted_use_id;
+alter table back.users drop column deleted_date;
+delete from public.knex_migrations where name ='20240711144251_back.roles__insert_desactivation.js'
+UPDATE back.users SET deleted = false
+*/
+exports.down = function (knex) {
+  return knex
+    .withSchema("back")
+    .table("roles")
+    .where({
+      label: "Desactivation",
+    })
+    .delete()
+    .then(function () {
+      return knex.schema
+        .withSchema("back")
+        .table("users", function (table) {
+          dropColumn("deleted_use_id");
+          dropColumn("deleted_date");
+        });
+    })    
+    .then(function () {
+      return knex.raw("DELETE FROM back.user_roles WHERE rol_id= 6")
+    })
+};


### PR DESCRIPTION
- Ajout du droit de désactivation d'un compte
- Le droit par défaut est a attribué à l'ensemble des profils Nationaux
- Si le droit n'est pas attribué alors l'utilisateur ne peut ni attribuer le droit ni désactiver des comptes
- Lorsque l'utilisateur a le droit de désactiver les comptes, il peut également attribuer le droit de désactivation.
- La date de désactivation est affiché au chargement de la fiche utilisateur
- Ajout d'un filtre "compte actif" dans la liste des utilisateurs BO
Un compte désactivé :
* N'est plus modifiable
* Ne peut plus se connecter 
* Ne reçoit plus de mail lors d'une réintialisation de mot de passe
* Ne peut plus utiliser un lien d'activation de compte ou changement de mot de passe.