### PR TITLE
fix : divers

### DIFF
--- a/packages/frontend-bo/src/components/demandes-sejour/DisplayTypePrecision.vue
+++ b/packages/frontend-bo/src/components/demandes-sejour/DisplayTypePrecision.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div>{{ props.typePrecision }}</div>
-    <pre v-if="props.commentaire">{{ props.commentaire }}</pre>
+    <span v-if="props.commentaire">{{ props.commentaire }}</span>
   </div>
 </template>
 
@@ -19,5 +19,6 @@ const props = defineProps({
   align-items: start;
   justify-content: center;
   height: 100%;
+  white-space: pre-line;
 }
 </style>

--- a/packages/frontend-bo/src/components/demandes-sejour/liste.vue
+++ b/packages/frontend-bo/src/components/demandes-sejour/liste.vue
@@ -135,7 +135,7 @@
       @close="closePrendEnChargeModal"
     >
       <article class="fr-mb-4v">
-        Vous vous apprêtez a prendre en charge la déclaration du séjour : <br />
+        Vous vous apprêtez à prendre en charge la déclaration du séjour : <br />
         - {{ declarationAPrendreEnCharge.libelle }}
       </article>
       <fieldset class="fr-fieldset">
@@ -326,7 +326,7 @@ const headers = [
     text: "Action",
     format: (value) =>
       value.estInstructeurPrincipal ? "A instruire" : "Lecture seule",
-    sort: true,
+    sort: false,
   },
 ];
 

--- a/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
+++ b/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
@@ -87,8 +87,7 @@
 <script setup>
 import dayjs from "dayjs";
 definePageMeta({
-  middleware: ["is-connected", "check-role"],
-  roles: ["Compte"],
+  middleware: ["is-connected"],
 });
 import { useUserStore } from "~/stores/user";
 const usersStore = useUserStore();

--- a/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
+++ b/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
@@ -70,8 +70,7 @@ const organismeStore = useOrganismeStore();
 const route = useRoute();
 const log = logger("pages/organismes/[[organismeId]]");
 definePageMeta({
-  middleware: ["is-connected", "check-role"],
-  roles: ["Compte"],
+  middleware: ["is-connected"],
 });
 
 const asc = ref(true);

--- a/packages/frontend-bo/src/pages/organismes/liste.vue
+++ b/packages/frontend-bo/src/pages/organismes/liste.vue
@@ -76,8 +76,7 @@
 <script setup>
 import dayjs from "dayjs";
 definePageMeta({
-  middleware: ["is-connected", "check-role"],
-  roles: ["Compte"],
+  middleware: ["is-connected"],
 });
 import { useOrganismeStore } from "~/stores/organisme";
 import { useRegionStore } from "~/stores/referentiels";

--- a/packages/frontend-bo/src/pages/sejours/index.vue
+++ b/packages/frontend-bo/src/pages/sejours/index.vue
@@ -9,7 +9,7 @@
       @close="closePrendEnChargeModal"
     >
       <article class="fr-mb-4v">
-        Vous vous apprêtez a prendre en charge la déclaration du séjour : <br />
+        Vous vous apprêtez à prendre en charge la déclaration du séjour : <br />
         - {{ declarationAPrendreEnCharge.libelle }}
       </article>
       <fieldset class="fr-fieldset">

--- a/packages/frontend-usagers/src/components/DS/DisplayTypePrecision.vue
+++ b/packages/frontend-usagers/src/components/DS/DisplayTypePrecision.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div>{{ props.typePrecision }}</div>
-    <pre v-if="props.commentaire">{{ props.commentaire }}</pre>
+    <span v-if="props.commentaire">{{ props.commentaire }}</span>
   </div>
 </template>
 
@@ -19,5 +19,6 @@ const props = defineProps({
   align-items: start;
   justify-content: center;
   height: 100%;
+  white-space: pre-line;
 }
 </style>


### PR DESCRIPTION
444 : Dans l’historique d’une déclaration, les dates sont manquantes car le tableau se décale au delà de la zone visible
493 : Sur le BackOffice en intégration et en préprod lorsqu’on clique sur “Action” pour filtrer il y’a une erreur qui apparait et le filtre ne renvoi pas les résultats attendus
516 :  tous les utilisateurs back office devraient avoir la visibilité des comptes des organisateurs (liste + détail). C’est apparemment limité et il n’y a aucune raison à cela
505 : typo