### PR TITLE
feat(personne): deplacement case à cocher 564

### DIFF
--- a/packages/frontend-usagers/src/components/DS/personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/personnel.vue
@@ -99,6 +99,20 @@
       />
     </div>
     <DsfrFieldset>
+      <div v-if="showAttestation" class="fr-col-12">
+        <div class="fr-fieldset__element">
+          <div class="fr-input-group fr-col-12">
+            <DsfrCheckbox
+              v-model="personnesAttestation"
+              name="attestation"
+              label="Je certifie sur l'honneur avoir vérifié que les personnes ci-dessus n’ont pas fait l’objet d’une condamnation inscrite au bulletin n°3 du casier judiciaire"
+              :small="true"
+              :disabled="!props.modifiable"
+              @update:model-value="certifiePersonnesAttestation(personnes)"
+            />
+          </div>
+        </div>
+      </div>    
       <div v-if="props.modifiable" class="fr-fieldset__element">
         <DsfrButton
           ref="modalOrigin"
@@ -165,6 +179,18 @@ const props = defineProps({
 const personnesWithId = computed(() =>
   [...(props.personnes ?? [])].map((p, index) => ({ ...p, id: index })),
 );
+
+const personnesAttestation = computed(() =>
+  personnesAttestationCertifie(props.personnes),
+);
+
+function personnesAttestationCertifie(personnes) {
+  return personnes.length > 0 && personnes.every(personne => personne.attestation === true);
+}
+
+function certifiePersonnesAttestation(personnes) {
+  personnes.forEach(personne => personne.attestation = true);
+}
 
 const emit = defineEmits(["updatePersonne"]);
 const log = logger("pages/component/personnel");
@@ -376,7 +402,7 @@ async function handlePaste(lignesCollees) {
     encadrantsFromCsv.push({
       nom,
       prenom,
-      attestation: true,
+      attestation: false,
       competence,
       listeFonction,
       dateNaissance,

--- a/packages/frontend-usagers/src/components/DS/personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/personnel.vue
@@ -108,7 +108,7 @@
               label="Je certifie sur l'honneur avoir vérifié que les personnes ci-dessus n’ont pas fait l’objet d’une condamnation inscrite au bulletin n°3 du casier judiciaire"
               :small="true"
               :disabled="!props.modifiable"
-              @update:model-value="certifiePersonnesAttestation(personnes)"
+              @update:model-value="true"
             />
           </div>
         </div>
@@ -180,17 +180,17 @@ const personnesWithId = computed(() =>
   [...(props.personnes ?? [])].map((p, index) => ({ ...p, id: index })),
 );
 
-const personnesAttestation = computed(() =>
-  personnesAttestationCertifie(props.personnes),
-);
 
-function personnesAttestationCertifie(personnes) {
-  return personnes.length > 0 && personnes.every(personne => personne.attestation === true);
-}
-
-function certifiePersonnesAttestation(personnes) {
-  personnes.forEach(personne => personne.attestation = true);
-}
+const personnesAttestation = computed({
+  get() {
+    return Array.isArray(props.personnes) && props.personnes.length > 0 && props.personnes.every(personne => personne.attestation);
+  },
+  set(value) {
+    if (Array.isArray(props.personnes)) {
+      props.personnes.forEach(personne => personne.attestation = value);
+    }
+  },
+});
 
 const emit = defineEmits(["updatePersonne"]);
 const log = logger("pages/component/personnel");

--- a/packages/frontend-usagers/src/components/personne.vue
+++ b/packages/frontend-usagers/src/components/personne.vue
@@ -147,20 +147,6 @@
           </div>
         </div>
       </div>
-      <div v-if="showAttestation" class="fr-col-12">
-        <div class="fr-fieldset__element">
-          <div class="fr-input-group fr-col-12">
-            <DsfrCheckbox
-              v-model="attestation"
-              name="attestation"
-              label="Je certifie sur l'honneur avoir vérifié que la personne ci dessus n’a pas fait l’objet d’une condamnation inscrite au bulletin n°3 du casier judiciaire"
-              :small="true"
-              :disabled="!props.modifiable"
-              @update:model-value="onAttestationChange"
-            />
-          </div>
-        </div>
-      </div>
     </fieldset>
     <fieldset v-if="showButton" class="fr-fieldset">
       <div class="fr-input-group">
@@ -201,7 +187,6 @@ const validationSchema = computed(() =>
   yup.object({
     ...personne.schema({
       showAdresse: props.showAdresse,
-      showAttestation: props.showAttestation,
       showCompetence: props.showCompetence,
       showDateNaissance: props.showDateNaissance,
       showEmail: props.showEmail,
@@ -218,9 +203,7 @@ const initialValues = {
   ...(props.showAdresse && {
     adresse: props.personne.adresse,
   }),
-  ...(props.showAttestation && {
     attestation: props.personne.attestation,
-  }),
   ...(props.showCompetence && {
     competence: props.personne.competence,
   }),


### PR DESCRIPTION
* Déplacement de la case “oui je certifie qu’il n’a pas de casier” au niveau global pour les personnels et accompagnants.
* Quel que soit le système d'ajout du personnel ou encadrant, la transmission de la déclaration ne sera pas possible si la case n'est pas cochée. Le personnel et/ou encadrant seront alors "incomplet"