### PR TITLE
Fix/fusager corrige personnel incomplet 564

### DIFF
--- a/packages/frontend-usagers/src/components/DS/informations-personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/informations-personnel.vue
@@ -88,9 +88,9 @@
             `Personnel d'encadrement - ${nombreResponsable ?? 0}&nbsp;`
           }}</span>
           <DsfrBadge
-            :label="encadrantsMeta.valid ? 'Complet' : 'Incomplet'"
+            :label="(encadrantsMeta.valid && encadrants.every(encadrant => encadrant.attestation)) ? 'Complet' : 'Incomplet'"
             :small="true"
-            :type="encadrantsMeta.valid ? 'success' : 'warning'"
+            :type="(encadrantsMeta.valid && encadrants.every(encadrant => encadrant.attestation)) ? 'success' : 'warning'"
           />
         </template>
         <div class="fr-fieldset__element fr-input-group fr-col-12">
@@ -121,9 +121,9 @@
             `Personnel d'accompagnement - ${nombreAccompagnant ?? 0}&nbsp;`
           }}</span>
           <DsfrBadge
-            :label="accompagnantsMeta.valid ? 'Complet' : 'Incomplet'"
+            :label="(accompagnantsMeta.valid && accompagnants.every(accompagnant => accompagnant.attestation)) ? 'Complet' : 'Incomplet'"
             :small="true"
-            :type="accompagnantsMeta.valid ? 'success' : 'warning'"
+            :type="(accompagnantsMeta.valid && accompagnants.every(accompagnant => accompagnant.attestation)) ? 'success' : 'warning'"
           />
         </template>
         <div class="fr-fieldset__element fr-input-group fr-col-12">

--- a/packages/frontend-usagers/src/components/DS/informations-personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/informations-personnel.vue
@@ -88,9 +88,19 @@
             `Personnel d'encadrement - ${nombreResponsable ?? 0}&nbsp;`
           }}</span>
           <DsfrBadge
-            :label="(encadrantsMeta.valid && encadrants.every(encadrant => encadrant.attestation)) ? 'Complet' : 'Incomplet'"
+            :label="
+              encadrantsMeta.valid &&
+              encadrants.every((encadrant) => encadrant.attestation)
+                ? 'Complet'
+                : 'Incomplet'
+            "
             :small="true"
-            :type="(encadrantsMeta.valid && encadrants.every(encadrant => encadrant.attestation)) ? 'success' : 'warning'"
+            :type="
+              encadrantsMeta.valid &&
+              encadrants.every((encadrant) => encadrant.attestation)
+                ? 'success'
+                : 'warning'
+            "
           />
         </template>
         <div class="fr-fieldset__element fr-input-group fr-col-12">
@@ -121,9 +131,19 @@
             `Personnel d'accompagnement - ${nombreAccompagnant ?? 0}&nbsp;`
           }}</span>
           <DsfrBadge
-            :label="(accompagnantsMeta.valid && accompagnants.every(accompagnant => accompagnant.attestation)) ? 'Complet' : 'Incomplet'"
+            :label="
+              accompagnantsMeta.valid &&
+              accompagnants.every((acc) => acc.attestation)
+                ? 'Complet'
+                : 'Incomplet'
+            "
             :small="true"
-            :type="(accompagnantsMeta.valid && accompagnants.every(accompagnant => accompagnant.attestation)) ? 'success' : 'warning'"
+            :type="
+              accompagnantsMeta.valid &&
+              accompagnants.every((acc) => acc.attestation)
+                ? 'success'
+                : 'warning'
+            "
           />
         </template>
         <div class="fr-fieldset__element fr-input-group fr-col-12">

--- a/packages/frontend-usagers/src/components/DS/personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/personnel.vue
@@ -168,11 +168,19 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import { DsfrFieldset } from "@gouvminint/vue-dsfr";
 
 dayjs.extend(customParseFormat);
-
+/*
 const dataExemplePersonnel = [
     {nom:"Durand",prenom:"philippe",dateNaissance:"1977-01-25",competence:"infirmier",listeFonction:["Distribution des médicaments","autre"],telephone:"0610203040"},
     {nom:"dupont",prenom:"Nathalie",dateNaissance:"1985-07-15",competence:"Cuisinière",listeFonction:["Restauration"],telephone:"+33612345678"},
   ];
+*/
+const dataExemplePersonnel = [
+  {nom:"Durand",prenom:"philippe",dateNaissance:"1977-01-25",competence:"infirmier",listeFonction:["Distribution des médicaments","autre"],telephone:"0610203040"},
+  {nom:"Dupont",prenom:"Nathalie",dateNaissance:"1985-07-155",competence:"Cuisinière",listeFonction:["Restauration"],telephone:"0610203041"},
+  {nom:"Dupond",prenom:"Kevin",dateNaissance:"1991-11-20",competence:"Guide",listeFonction:["Activités spécifiques"],telephone:"0780101010"},
+  {nom:"Payet",prenom:"Carole",dateNaissance:"1966-10-01",competence:"Chauffeur",listeFonction:["Transport des vacanciers"],telephone:"0610102010"},
+  {nom:"Merlin",prenom:"Nathalie",dateNaissance:"1980-08-02",competence:"Agent d'entretien",listeFonction:["Entretien des locaux"],telephone:"0602060202"},
+];
 
 const DsfrBadge = resolveComponent("DsfrBadge");
 

--- a/packages/frontend-usagers/src/components/DS/personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/personnel.vue
@@ -168,19 +168,11 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import { DsfrFieldset } from "@gouvminint/vue-dsfr";
 
 dayjs.extend(customParseFormat);
-/*
+
 const dataExemplePersonnel = [
     {nom:"Durand",prenom:"philippe",dateNaissance:"1977-01-25",competence:"infirmier",listeFonction:["Distribution des médicaments","autre"],telephone:"0610203040"},
     {nom:"dupont",prenom:"Nathalie",dateNaissance:"1985-07-15",competence:"Cuisinière",listeFonction:["Restauration"],telephone:"+33612345678"},
   ];
-*/
-const dataExemplePersonnel = [
-  {nom:"Durand",prenom:"philippe",dateNaissance:"1977-01-25",competence:"infirmier",listeFonction:["Distribution des médicaments","autre"],telephone:"0610203040"},
-  {nom:"Dupont",prenom:"Nathalie",dateNaissance:"1985-07-155",competence:"Cuisinière",listeFonction:["Restauration"],telephone:"0610203041"},
-  {nom:"Dupond",prenom:"Kevin",dateNaissance:"1991-11-20",competence:"Guide",listeFonction:["Activités spécifiques"],telephone:"0780101010"},
-  {nom:"Payet",prenom:"Carole",dateNaissance:"1966-10-01",competence:"Chauffeur",listeFonction:["Transport des vacanciers"],telephone:"0610102010"},
-  {nom:"Merlin",prenom:"Nathalie",dateNaissance:"1980-08-02",competence:"Agent d'entretien",listeFonction:["Entretien des locaux"],telephone:"0602060202"},
-];
 
 const DsfrBadge = resolveComponent("DsfrBadge");
 

--- a/packages/frontend-usagers/src/utils/informationsPersonnel.js
+++ b/packages/frontend-usagers/src/utils/informationsPersonnel.js
@@ -42,7 +42,6 @@ const schema = (statut) => {
           yup.object(
             personne.schema({
               showAdresse: false,
-              showAttestation: true,
               showFonction: false,
               showCompetence: true,
               showDateNaissance: true,
@@ -62,7 +61,6 @@ const schema = (statut) => {
           yup.object(
             personne.schema({
               showAdresse: false,
-              showAttestation: true,
               showFonction: false,
               showCompetence: true,
               showDateNaissance: true,

--- a/packages/shared/src/components/TableFull.vue
+++ b/packages/shared/src/components/TableFull.vue
@@ -198,13 +198,13 @@ const filteredData = computed(() => {
 });
 
 const displayableData = computed(() => {
-  return filteredData.value.map((item) => {
+  return filteredData.value.map((item, index) => {
     const rowdata = h.value.map((header) => {
       if (header.component) {
         return header.component(item) ?? "";
       }
       if (header.format) {
-        return header.format(item) ?? "";
+        return header.format(item, index) ?? "";
       }
       if (header.objectLabel) {
         return item[header.column]?.[header.objectLabel] ?? "";


### PR DESCRIPTION
VAO-564
Correction de l'affichage "Incomplet" sur la J-8 au niveau du personnel encadrant et des accompagnateurs.
Désormais Complet apparait que lorsqu'il y a au moins un personnel et que la case est cochée (vérification casier judiciaire).