### PR TITLE
fix(liste-decla-sejour): tri par défaut #536

### DIFF
--- a/packages/backend/src/services/DemandeSejour.js
+++ b/packages/backend/src/services/DemandeSejour.js
@@ -250,6 +250,7 @@ FROM front.demande_sejour ds
 JOIN front.organismes o ON o.id = ds.organisme_id
 WHERE
   o.id  = ANY ($1)
+ORDER BY ds.edited_at DESC
 `,
     [organismeIds],
   ],
@@ -936,9 +937,9 @@ module.exports.getByDepartementCodes = async (
 
   // Order management
   if (sortBy && sortDirection) {
-    queryWithPagination += `ORDER BY "${sortBy}" ${sortDirection}, "createdAt" DESC`;
+    queryWithPagination += `ORDER BY "${sortBy}" ${sortDirection}, ds.edited_at DESC`;
   } else {
-    queryWithPagination += 'ORDER BY "createdAt" DESC';
+    queryWithPagination += "ORDER BY ds.edited_at DESC";
   }
 
   const paramsWithPagination = [...params];


### PR DESCRIPTION
Ajout d'un tri par défaut sur la date de modification des déclarations de séjour
- BO
- FUsager

nb : Il faudra faire pour le get de declaration_sejour la la même chose que pour les autres, c-a-d passer par un param avec les paramètres { limit, offset, sortBy, sortDirection, search }
ça n'a pas été fait pas défaut et nécessite plus de temps pour l'implémentation. Donc dans l'immédiat le ORDER BY est mis directement dans la Query au niveau du service.