### PR TITLE
fix(bo-comptes): correction création de comptes 640

### DIFF
--- a/packages/frontend-bo/src/components/user/Compte.vue
+++ b/packages/frontend-bo/src/components/user/Compte.vue
@@ -88,8 +88,7 @@
                 </div>
               </div>
               <div
-                class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8"
-              >
+                class="fr-fieldset__element fr-col-12 fr-col-sm-8 fr-col-md-8 fr-col-lg-8 fr-col-xl-8">
                 <div class="fr-fieldset__element">
                   <div class="fr-input-group fr-col-12">
                     <DsfrRadioButtonSet
@@ -265,24 +264,24 @@ const departementStore = useDepartementStore();
 departementStore.fetch();
 
 const userDepartements = computed(() => {
-  if (props.user.territoireCode === "FRA") {
+  if (usersStore.user.territoireCode === "FRA" || isFormDisabled.value) {
     return departementStore.departements;
   }
   const departementsByRegion = departementStore.departements.filter(
-    (d) => d.region === props.user.territoireCode,
+    (d) => d.region === usersStore.user.territoireCode,
   );
   if (departementsByRegion?.length) {
     return departementsByRegion;
   }
   return (
     departementStore.departements.filter(
-      (d) => d.value === props.user.territoireCode,
+      (d) => d.value === usersStore.user.territoireCode,
     ) ?? []
   );
 });
 
 const userRegions = computed(() => {
-  if (usersStore.user.territoireCode === "FRA") {
+  if (usersStore.user.territoireCode === "FRA" || isFormDisabled.value) {
     return regionStore.regions;
   }
   return (
@@ -501,17 +500,22 @@ watch([() => serviceCompetenceField.modelValue], function () {
 onMounted(async () => {
   log.i("Mounted - IN");
   serviceCompetenceOptions = [];
+  if (!usersStore.user.serviceCompetent) {
+    await usersStore.refreshProfile();
+  }
   if (isFormDisabled.value) {
     serviceCompetenceOptions.push(serviceCompetenceNAT);
     serviceCompetenceOptions.push(serviceCompetenceREG);
   } else {
-    if (usersStore.user.serviceCompetent === competence.NATIONALE)
+    if (usersStore.user.serviceCompetent === competence.NATIONALE) {
       serviceCompetenceOptions.push(serviceCompetenceNAT);
+    }
     if (
       usersStore.user.serviceCompetent === competence.NATIONALE ||
       usersStore.user.serviceCompetent === competence.REGIONALE
-    )
+    ) {
       serviceCompetenceOptions.push(serviceCompetenceREG);
+    }
   }
   serviceCompetenceOptions.push(serviceCompetenceDEP);
   // Mode Edition

--- a/packages/frontend-bo/src/stores/user.js
+++ b/packages/frontend-bo/src/stores/user.js
@@ -29,7 +29,7 @@ export const useUserStore = defineStore("user", {
           this.user.serviceCompetent =
             this.user.territoireCode === "FRA"
               ? "NAT"
-              : /^"\d"+$/.test(user.territoireCode)
+              : /^\d+$/.test(this.user.territoireCode)
                 ? "DEP"
                 : "REG";
         }


### PR DESCRIPTION
- Correction de la liste vide (département lors de la création des comptes)
- Correction de la mauvaise interprétation d'une compétence départemental en compétence régionale
- Correction d'affichage de la région et département lorsque le compte est en lecture seule est que l'on était hors du service de compétence. 