### PR TITLE
fix(FOPersonnel): fonctions vides dans tableau 656

### DIFF
--- a/packages/frontend-usagers/src/components/DS/personnel.vue
+++ b/packages/frontend-usagers/src/components/DS/personnel.vue
@@ -330,6 +330,7 @@ const headers = [
     sorter: "listeFonction",
     objectLabel: "listeFonction",
     text: "Fonctions",
+    format: (value) => value.listeFonction.join(", "),
     headerAttrs: {
       class: "suivi",
     },


### PR DESCRIPTION
Correction des fonctions des personnels et envadrants vides dans les tableaux FO