### PR TITLE
fix(BO): ouverture déclaration pour org non porteur agrement

### DIFF
--- a/packages/backend/src/middlewares/checkPermissionBODeclarationSejour.js
+++ b/packages/backend/src/middlewares/checkPermissionBODeclarationSejour.js
@@ -21,35 +21,102 @@ async function checkPermissionDeclarationSejour(req, res, next) {
     );
   }
 
+  // Requête SQL simplifiée, ne récupérant que les informations brutes nécessaires
   const query = `
-      SELECT
-         ds.id
-      FROM front.demande_sejour ds
-      JOIN front.agrements a ON a.organisme_id = ds.organisme_id
-      WHERE ds.id = $1
-      AND (
-        a.region_obtention = $2
-        OR jsonb_path_query_array(hebergement, '$.hebergements[*].coordonnees.adresse.departement') ?| ($3)::text[]
-      )
-    `;
-  const { rows } = await pool.query(query, [
-    declarationId,
-    territoireCode,
-    departements.map((d) => d.value),
-  ]);
+    SELECT ds.id, ds.hebergement, o.personne_morale, agr.region_obtention
+    FROM front.demande_sejour ds
+    INNER JOIN front.organismes o ON o.id = ds.organisme_id
+    LEFT JOIN front.agrements agr ON agr.organisme_id = ds.organisme_id
+    WHERE ds.id = $1
+  `;
 
-  if (!rows || rows.length !== 1) {
+  let sejour;
+  try {
+    const { rows } = await pool.query(query, [declarationId]);
+    if (!rows || rows.length === 0) {
+      return next(
+        new AppError(
+          "Vous n'êtes pas autorisé à accéder à cette déclaration de séjour",
+          {
+            statusCode: 403,
+          },
+        ),
+      );
+    }
+    // Récupération des données brutes
+    sejour = rows[0];
+  } catch (err) {
+    log.w(err);
+    return next(
+      new AppError("La recheche du séjour et de l'organisateur ont échoué", {
+        cause: err,
+      }),
+    );
+  }
+
+  const { hebergement, personne_morale, region_obtention } = sejour;
+
+  // Traitement des données JSON pour vérifier les départements
+  const hebergements = hebergement?.hebergements || [];
+  const departementsHebergements = hebergements.map(
+    (h) => h.coordonnees?.adresse?.departement,
+  );
+
+  const hasValidDepartement = departements.some((dep) =>
+    departementsHebergements.includes(dep.value),
+  );
+
+  if (hasValidDepartement) {
+    return next();
+  }
+
+  try {
+    // Vérification supplémentaire sur les organismes et leur agrément
+    if (!personne_morale?.porteurAgrement) {
+      // Si l'agrément n'est pas "porteur", il faut vérifier les organismes liés
+      const queryOrganismeAgre = `
+        SELECT agr.region_obtention
+        FROM front.organismes o
+        INNER JOIN front.agrements agr ON agr.organisme_id = o.id
+        WHERE o.personne_morale->>'siret' = $1
+      `;
+      const { rows: agrements } = await pool.query(queryOrganismeAgre, [
+        personne_morale.etablissementPrincipal?.siret,
+      ]);
+
+      const hasAgrement = agrements.some(
+        (agr) => agr.region_obtention === territoireCode,
+      );
+      if (hasAgrement) {
+        return next();
+      }
+    } else {
+      //  Vérification sur la région d'obtention (Organisme porteur de l'agrément)
+      if (region_obtention === territoireCode) {
+        return next();
+      }
+    }
+  } catch (err) {
+    log.w(err);
     return next(
       new AppError(
-        "Vous n'êtes pas autorisé à accéder à cette déclaration de séjour",
+        "La recheche de l'agrément de l'organisateur principal a échoué",
         {
-          statusCode: 403,
+          cause: err,
         },
       ),
     );
   }
-  log.i("DONE");
-  next();
+
+  // Si aucune des conditions n'est remplie, accès refusé
+  return next(
+    new AppError(
+      "Vous n'êtes pas autorisé à accéder à cette déclaration de séjour",
+      {
+        statusCode: 403,
+      },
+    ),
+  );
 }
 
 module.exports = checkPermissionDeclarationSejour;


### PR DESCRIPTION
Pour les users BO il n'était pas possible de remonter à l'agrément si le séjour est déclaré avec un organisateur qui n'est pas porteur de l'agrément.
Séparation en deux de la recherche de l'agrément, l'un pour le porteur l'autre pour le non porteur.