### PR TITLE
fix(export-bo-user): ajout de la région même pour les départements 639

### DIFF
--- a/packages/backend/src/services/BoUser.js
+++ b/packages/backend/src/services/BoUser.js
@@ -148,8 +148,8 @@ const query = {
         GROUP BY use_id
     ) ur ON ur.use_id = us.id
     LEFT OUTER JOIN geo.territoires ter on ter.code = us.ter_code
-    LEFT OUTER JOIN geo.territoires reg ON reg.code = ter.code AND ter.parent_code = 'FRA'
     LEFT OUTER JOIN geo.territoires dep ON dep.code = us.ter_code AND dep.parent_code <> 'FRA'
+    LEFT OUTER JOIN geo.territoires reg ON ((reg.code = ter.code AND ter.parent_code = 'FRA') or (dep.parent_code = reg.code)) 
     LEFT OUTER JOIN back.users ud on ud.id = us.deleted_use_id
     WHERE 1 = 1
 ${Object.keys(criterias)


### PR DESCRIPTION
Ajout de la région dans l'export CSV des agents même pour les compétences départementales afin de permettre de filtrer par région dans le tableur.