### PR TITLE
fix(FUsager): problème de création de compte

### DIFF
--- a/packages/backend/src/services/User.js
+++ b/packages/backend/src/services/User.js
@@ -95,11 +95,11 @@ const query = {
         us.telephone as "telephone",
         us.created_at as "createdAt",
         us.status_code as "statusCode",
-        o.personne_morale->>'siret' as "siret"
+        o.personne_morale->>'siret' as "siret",
         o.personne_morale->>'raisonSociale' as "raisonSociale"
       FROM front.users us
-      INNER JOIN front.user_organisme uo ON us.id = uo.use_id
-      INNER JOIN front.organismes o ON uo.org_id = o.id
+      LEFT JOIN front.user_organisme uo ON us.id = uo.use_id
+      LEFT JOIN front.organismes o ON uo.org_id = o.id
       WHERE 1=1
       ${Object.keys(criterias)
         .map((criteria, i) => ` AND us.${criteria} = $${i + 1}`)
@@ -134,7 +134,7 @@ const query = {
       us.telephone as "telephone",
       us.created_at as "createdAt",
       us.status_code as "statusCode",
-      o.personne_morale->>'siret' as "siret"
+      o.personne_morale->>'siret' as "siret",
       o.personne_morale->>'raisonSociale' as "raisonSociale"
     FROM front.users us
     INNER JOIN updated_user uu ON us.id = uu.id


### PR DESCRIPTION
Fix : 
- virgule manquante sur requête recherche utilisateur
- INNER JOIN qui ne fonctionne pas lorsque l'utilisateur créé son compte car il n'est lié à aucun organisme. Il faudrait faire une requête séparée s'il y a un effet de bord
