### PR TITLE
fix(organismes): yup pour etablissement secondaire

### DIFF
--- a/packages/backend/src/schemas/organisme.js
+++ b/packages/backend/src/schemas/organisme.js
@@ -249,7 +249,7 @@ const schema = (regions) => ({
     is: (typeOrganisme, siegeSocial) => {
       return typeOrganisme === "personne_physique" || siegeSocial === true;
     },
-    otherwise: (schema) => schema.nullable(),
+    otherwise: (schema) => schema.shape(agrementSchema(regions)).nullable(),
     then: (schema) =>
       schema
         .shape(agrementSchema(regions))
@@ -271,33 +271,11 @@ const schema = (regions) => ({
       then: (schema) => schema.shape(personnePhysiqueSchema()),
     }),
   protocoleSanitaire: yup
-    .object()
-    .when(["typeOrganisme", "personneMorale.porteurAgrement"], {
-      is: (typeOrganisme, porteurAgrement) => {
-        return (
-          typeOrganisme === "personne_physique" || porteurAgrement === true
-        );
-      },
-      otherwise: (schema) => schema.nullable(),
-      then: (schema) =>
-        schema
-          .shape(protocoleSanitaireSchema())
-          .required("Aucune information renseignée"),
-    }),
+    .object(protocoleSanitaireSchema())
+    .required("Aucune information renseignée"),
   protocoleTransport: yup
-    .object()
-    .when(["typeOrganisme", "personneMorale.porteurAgrement"], {
-      is: (typeOrganisme, porteurAgrement) => {
-        return (
-          typeOrganisme === "personne_physique" || porteurAgrement === true
-        );
-      },
-      otherwise: (schema) => schema.nullable(),
-      then: (schema) =>
-        schema
-          .shape(protocoleTransportSchema())
-          .required("Aucune information renseignée"),
-    }),
+    .object(protocoleTransportSchema())
+    .required("Aucune information renseignée"),
   typeOrganisme: yup
     .string()
     .required()

--- a/packages/backend/src/services/Organisme.js
+++ b/packages/backend/src/services/Organisme.js
@@ -12,8 +12,6 @@ const Organisme = require("../schemas/organisme");
 
 const log = logger(module.filename);
 
-let regions, organismeSchema;
-
 const query = {
   create: `
     INSERT INTO front.organismes (type_organisme, personne_morale, personne_physique)
@@ -385,9 +383,8 @@ module.exports.update = async (type, parametre, organismeId) => {
   log.i("update - IN", { type });
   let response;
 
-  if (!regions) {
-    regions = await Regions.fetch();
-  }
+  const regions = await Regions.fetch();
+
   switch (type) {
     case "personne_morale": {
       const complet =
@@ -449,12 +446,10 @@ module.exports.update = async (type, parametre, organismeId) => {
 
 module.exports.finalize = async function (userId) {
   log.i("finalize - IN", { userId });
-  if (!regions) {
-    regions = await Regions.fetch();
-  }
-  if (!organismeSchema) {
-    organismeSchema = Organisme.schema(regions);
-  }
+  const regions = await Regions.fetch();
+
+  const organismeSchema = Organisme.schema(regions);
+
   const criterias = {
     "uo.use_id": userId,
   };

--- a/packages/frontend-usagers/src/utils/organisme.js
+++ b/packages/frontend-usagers/src/utils/organisme.js
@@ -281,32 +281,14 @@ const schema = (regions) => ({
       schema
         .shape(agrementSchema(regions))
         .required("Aucune information renseignée"),
-    otherwise: (schema) => schema.nullable(),
+    otherwise: (schema) => schema.shape(agrementSchema(regions)).nullable(),
   }),
   protocoleTransport: yup
-    .object()
-    .when(["typeOrganisme", "personneMorale.siegeSocial"], {
-      is: (typeOrganisme, siegeSocial) => {
-        return typeOrganisme === "personne_physique" || siegeSocial === true;
-      },
-      then: (schema) =>
-        schema
-          .shape(protocoleTransport.schema)
-          .required("Aucune information renseignée"),
-      otherwise: (schema) => schema.nullable(),
-    }),
+    .object(protocoleTransport.schema)
+    .required("Aucune information renseignée"),
   protocoleSanitaire: yup
-    .object()
-    .when(["typeOrganisme", "personneMorale.siegeSocial"], {
-      is: (typeOrganisme, siegeSocial) => {
-        return typeOrganisme === "personne_physique" || siegeSocial === true;
-      },
-      then: (schema) =>
-        schema
-          .shape(protocoleSanitaire.schema)
-          .required("Aucune information renseignée"),
-      otherwise: (schema) => schema.nullable(),
-    }),
+    .object(protocoleSanitaire.schema)
+    .required("Aucune information renseignée"),
 });
 
 export default {


### PR DESCRIPTION
close jira 695 696.

Le yup etait mal ecrit pour protocole transport et protocole sanitaire dans le cas des etablissemebnt secondaires. il manquait un `shape` pour indiquer le contenu de l'objet et a la validation, les champs etaient supprimés.

Cela dit, vu avec Vincent, jusqu'a présent, la validation considérait comme optionnel la declaration des protocoles de transports et sanitaire dans le cas des organismes secondaires. Ca n'as pas de sens, on a simplifé la logique 