### PR TITLE
fix(bo-csv): retrait bouton extraire les comptes en CSV 632

### DIFF
--- a/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
+++ b/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
@@ -48,14 +48,6 @@
             :headers="['Nom', 'Prenom', 'Email', 'Date inscription']"
             :rows="usersWithSiret"
           ></DsfrTable>
-          <div class="fr-input-group">
-            <DsfrButton
-              type="button"
-              label="Extraire les comptes en CSV"
-              primary
-              @click="getCsvUtilisateurs"
-            />
-          </div>
         </div>
         <div
           v-if="
@@ -198,13 +190,6 @@ const organismeName = computed(() => {
       : (organismeStore.organisme.personnePhysique.nomUsage ?? "");
   }
 });
-
-const getCsvUtilisateurs = async () => {
-  const response = await userStore.exportUsersOrganisme({
-    organismeId: organismeStore.organisme.organismeId,
-  });
-  exportCsv(response, "UtilisateursOrganisme.csv");
-};
 
 onMounted(async () => {
   try {

--- a/packages/frontend-bo/src/stores/user.js
+++ b/packages/frontend-bo/src/stores/user.js
@@ -83,24 +83,6 @@ export const useUserStore = defineStore("user", {
       }
     },
 
-    async exportUsersOrganisme({ organismeId } = {}) {
-      log.i("exportUsersOrganisme - IN");
-      try {
-        const response = await $fetchBackend(
-          `/fo-user/admin/extract/${organismeId}`,
-          {
-            method: "GET",
-            credentials: "include",
-          },
-        );
-        log.i("exportUsersOrganisme - DONE");
-        return response;
-      } catch (err) {
-        log.w("exportUsersOrganisme - DONE with error", err);
-        throw err;
-      }
-    },
-
     async fetchUsersOrganisme({
       limit,
       offset,


### PR DESCRIPTION
Retrait du bouton côté Front car il n'a pas été placé dans le bon écran et ne correspond par à la demande.
Suppression dans le store également pour éviter le code mort.
L'US sera reprise au prochaine Sprint, le back sera modifié en conséquence et bouton recréé au bon endroit sur le front