### PR TITLE
feat(bo-fusers): export csv des utilisateurs front 632

### DIFF
--- a/packages/backend/src/routes/fo-user.js
+++ b/packages/backend/src/routes/fo-user.js
@@ -8,11 +8,7 @@ const FOUserController = require("../controllers/fo-user");
 
 // Renvoie la liste des utilisateurs du BO
 router.get("/admin/list", BOcheckJWT, FOUserController.list);
-router.get(
-  "/admin/extract/:organismeId",
-  BOcheckJWT,
-  FOUserController.getExtract,
-);
+router.get("/admin/extract/", BOcheckJWT, FOUserController.getExtract);
 router.get("/list", checkJWT, FOUserController.list);
 
 module.exports = router;

--- a/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
+++ b/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
@@ -83,6 +83,14 @@
       @update-items-by-page="updateItemsByPage"
       @update-current-page="updateCurrentPage"
     />
+    <div class="fr-input-group">
+      <DsfrButton
+        type="button"
+        label="Extraire en CSV"
+        primary
+        @click="getCsvUtilisateurs"
+      />
+    </div>
   </div>
 </template>
 
@@ -134,6 +142,12 @@ const fetchUsersDebounce = debounce((search) => {
     search,
   });
 });
+
+const getCsvUtilisateurs = async () => {
+  const response = await usersStore.exportUsersOrganismes();
+  exportCsv(response, "UtilisateursOrganismes.csv");
+};
+
 watch([searchState], ([searchValue]) => {
   fetchUsersDebounce(searchValue);
 });

--- a/packages/frontend-bo/src/stores/user.js
+++ b/packages/frontend-bo/src/stores/user.js
@@ -82,6 +82,18 @@ export const useUserStore = defineStore("user", {
         throw err;
       }
     },
+    async exportUsersOrganismes() {
+      log.i("exportUsersOrganismes - IN");
+      try {
+        return await $fetchBackend(`/fo-user/admin/extract/`, {
+          method: "GET",
+          credentials: "include",
+        });
+      } catch (err) {
+        log.w("exportUsersOrganismes - DONE with error", err);
+        throw err;
+      }
+    },
 
     async fetchUsersOrganisme({
       limit,


### PR DESCRIPTION
En remplacement du dév précédent qui avait été placé au mauvais endroit.
Ici on exporte la listes des utilisateur FUsager du côté BO.
Réutilisation des routes déjà en place en supprimant le paramètre organismeId.