### PR TITLE
feat(BO): change filtrage liste sejour org princ sec 670

### DIFF
--- a/packages/backend/src/services/DemandeSejour.js
+++ b/packages/backend/src/services/DemandeSejour.js
@@ -1058,8 +1058,15 @@ module.exports.getByDepartementCodes = async (
 
   const params = [];
   const searchQuery = [];
-
   // Search management
+  if (search?.siren && search.siren.length) {
+    searchQuery.push(`o.personne_morale->>'siren' = $${params.length + 1}`);
+    params.push(`${search.siren}`);
+  }
+  if (search?.siret && search.siret.length) {
+    searchQuery.push(`o.personne_morale->>'siret' = $${params.length + 1}`);
+    params.push(`${search.siret}`);
+  }
   if (search?.idFonctionnelle && search.idFonctionnelle.length) {
     searchQuery.push(`id_fonctionnelle ILIKE $${params.length + 1}`);
     params.push(`%${search.idFonctionnelle}%`);

--- a/packages/frontend-bo/src/components/demandes-sejour/liste.vue
+++ b/packages/frontend-bo/src/components/demandes-sejour/liste.vue
@@ -182,6 +182,7 @@ definePageMeta({
 
 const props = defineProps({
   organisme: { type: String, required: false, default: null },
+  organismeId: { type: Number, required: false, default: null },
   display: { type: String, required: true },
 });
 
@@ -226,6 +227,7 @@ const searchState = reactive({
   libelle: route.query.libelle,
   idFonctionnelle: route.query.idFonctionnelle,
   organisme: props.organisme ?? route.query.organisme,
+  organismeId: props.organismeId ?? null,
   statuts: route.query.statuts
     ? route.query.statuts
         .split(",")

--- a/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
+++ b/packages/frontend-bo/src/pages/organismes/[[organismeId]].vue
@@ -122,6 +122,7 @@
           v-if="organismeName"
           display="Organisme"
           :organisme="organismeName"
+          :organisme-id="route.params.organismeId"
         ></DemandesSejourListe>
       </DsfrTabContent>
     </DsfrTabs>


### PR DESCRIPTION
Filtrage par siren ou siret pour la récupération des séjour (personne morales) afin de permettre de voir tous les séjours de tous les organismes principaux et secondaire lorsque c'est un organisme principal et ne voir que les séjours de l'organisme secondaire lorsque c'est un organisme secondaire