### PR TITLE
fix(fusager): DS ajout liste hébergement sans limite avec statut actif

### DIFF
--- a/packages/backend/src/services/hebergement/Hebergement.js
+++ b/packages/backend/src/services/hebergement/Hebergement.js
@@ -577,6 +577,12 @@ module.exports.getByUserId = async (userId, queryParams) => {
     },
     {
       filterEnabled: true,
+      key: "hs.value",
+      queryKey: "statut",
+      type: "default",
+    },
+    {
+      filterEnabled: true,
       key: "uo.use_id",
       queryKey: "userId",
       type: "number",

--- a/packages/frontend-usagers/src/components/DS/hebergements-sejour.vue
+++ b/packages/frontend-usagers/src/components/DS/hebergements-sejour.vue
@@ -143,6 +143,10 @@ const { value: hebergements, handleChange: onHebergementsChange } =
 hebergementStore.fetch({
   organismeId: demandeSejourStore.demandeCourante.organismeId,
   statut: hebergementUtils.statut.ACTIF,
+  // TO DO : Juste pour le hotfix. A élargir avec valeur par défaut dans applyPagination
+  limit: 10000,
+  offset: 0,
+  sortBy: "nom",
 });
 
 const syntheseRows = computed(() => {


### PR DESCRIPTION
## Tickets liés
Close #
tickets liés : https://jira-mcas.atlassian.net/browse/VAO-835

## Description
Sur la liste des hébergements proposés dans une DS FUsager
- Ajout d'une limite "infinie"car par défaut il propose les 10 premiers
- Ajout d'un tri par nom
- Correction de la prise en compte du statut actif pour le filtrage

### dont régressions potentielles à tester

## Check-list

 - [X] Ma branche est rebase sur main
 - [NA] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [NA] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`

