### PR TITLE
feat(fusager): interdiction de récupérer un siret fermé 847

### DIFF
--- a/packages/backend/src/controllers/siret/get.js
+++ b/packages/backend/src/controllers/siret/get.js
@@ -53,6 +53,14 @@ module.exports = async function get(req, res, next) {
         }),
       );
     }
+    if (
+      uniteLegale?.periodesEtablissement[0]?.etatAdministratifEtablissement ===
+      "F"
+    ) {
+      return res
+        .status(403)
+        .json({ message: "Etablissement fermé, opération non autorisée" });
+    }
     if (uniteLegale.uniteLegale.categorieJuridiqueUniteLegale) {
       uniteLegale.uniteLegale.categorieJuridiqueUniteLegale =
         (await Referentiel.getLibelle(

--- a/packages/frontend-usagers/src/components/organisme/personne-morale.vue
+++ b/packages/frontend-usagers/src/components/organisme/personne-morale.vue
@@ -457,11 +457,19 @@ async function searchApiInsee() {
       etablissementPrincipal,
     });
   } catch (error) {
-    toaster.error({
-      titleTag: "h2",
-      description:
-        "erreur lors de la récupération des données à partir du SIRET",
-    });
+    if (error.response?.status === 403) {
+      toaster.error({
+        titleTag: "h2",
+        description:
+          "Le SIRET renseigné n’est plus valide. Veuillez utiliser le nouveau SIRET de votre établissement",
+      });
+    } else {
+      toaster.error({
+        titleTag: "h2",
+        description:
+          "erreur lors de la récupération des données à partir du SIRET",
+      });
+    }
     log.w("searchApiInsee - erreur:", { error });
     setValues({
       siren: null,


### PR DESCRIPTION
## Tickets liés
tickets liés : 847

## Description
Contrôle sur le fait que l'établissement ne soit pas administrativement fermé lors de la récupération des informations au niveau de l'API Insee lors de la création d'une nouvelle personne morale.
### dont régressions potentielles à tester

## Screenshot / liens loom 

## Check-list

 - [X] Ma branche est rebase sur main
 - [] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`

