### PR TITLE
fix(fusager): display button list decla sejours

### DIFF
--- a/packages/frontend-usagers/src/components/demande-sejour/table.vue
+++ b/packages/frontend-usagers/src/components/demande-sejour/table.vue
@@ -33,7 +33,7 @@
     <template #cell-editedAt="{ cell }">
       {{ displayDate(cell) }}
     </template>
-    <template #cell:custom-edit="{ row }">
+    <template #cell-custom:edit="{ row }">
       <div class="buttons-group">
         <NuxtLink
           :to="`/demande-sejour/${row.declarationId}?defaultTabIndex=0`"


### PR DESCRIPTION
Regression sur la mise à jour DSFR : oubli sur la liste des déclaration de séjour. Effet de bord : disparition des boutons
Branch concernée : feat/improve-DataTable