### PR TITLE
fix(bo): accès fiche organisme suite à refacto

### DIFF
--- a/packages/backend/src/services/Organisme.js
+++ b/packages/backend/src/services/Organisme.js
@@ -739,8 +739,8 @@ module.exports.getOne = async (criterias = {}) => {
       statusCode: 404,
     });
   }
+  const organisme = await getComplementOrganisme(organismes[0]);
   // Initialisation d'une valeur vide pour permettre l'affichage au niveau front BO
-  const organisme = organismes[0];
   if (organisme?.personnePhysique) {
     organisme.personnePhysique.nomUsage =
       organisme.personnePhysique?.nomUsage ?? "";
@@ -751,13 +751,15 @@ module.exports.getOne = async (criterias = {}) => {
 
 module.exports.getBySiren = async (siren) => {
   log.i("getBySiren - IN", { siren });
-  const { rowCount, rows: organismes } = await pool.query(query.getBySiren, [siren]);
+  const { rowCount, rows: organismes } = await pool.query(query.getBySiren, [
+    siren,
+  ]);
   if (rowCount === 0) {
     log.i("getBySiren - Aucune correspondance trouvée");
     return [];
   }
   const organismesCompletes = await Promise.all(
-    organismes.map((organisme) => getComplementOrganisme(organisme))
+    organismes.map((organisme) => getComplementOrganisme(organisme)),
   );
   log.i("getBySiren - DONE");
   return organismesCompletes;


### PR DESCRIPTION
## Tickets liés
tickets liés : VAO-870

## Description
Correction de la non récupération des données nécessaires à l'affichage de l'organisme sur la fonction getOne suite à refacto.
Erreur uniquement côté BO.

### dont régressions potentielles à tester

## Screenshot / liens loom 

## Check-list

 - [X] Ma branche est rebase sur main
 - [] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`

