### PR TITLE
fix(fusager): suppr controle date début séjour en cours 724

### DIFF
--- a/packages/frontend-usagers/src/utils/DeclarationSejour.js
+++ b/packages/frontend-usagers/src/utils/DeclarationSejour.js
@@ -67,10 +67,18 @@ const baseSchema = {
     .typeError("le libellé est requis")
     .required(),
   dateDebut: yup
-    .date("Vous devez saisir une date valide au format JJ/MM/AAAA")
-    .typeError("date invalide")
-    .min(new Date(), "La date doit être supérieure à la date du jour.")
-    .required("La saisie de ce champ est obligatoire"),
+    .date()
+    .typeError("Vous devez saisir une date valide au format JJ/MM/AAAA")
+    .required("La saisie de ce champ est obligatoire")
+    .when("statut", {
+      is: (statut) => statut !== statusUtils.SEJOUR_EN_COURS,
+      then: (schema) =>
+        schema.min(
+          new Date(),
+          "La date doit être supérieure à la date du jour.",
+        ),
+      otherwise: (schema) => schema,
+    }),
   dateFin: yup
     .date("Vous devez saisir une date valide au format JJ/MM/AAAA")
     .typeError("date invalide")


### PR DESCRIPTION
## Tickets liés
724 
Fix du contrôle sur la date de début qui bloque la mise à jour. La date n'est pas modifié, on fait sauter les contrôle pour ne pas bloquer les autres mises à jour.