### PR TITLE
fix(bo) display menu validation ova after connect

### DIFF
--- a/packages/frontend-bo/src/pages/connexion/index.vue
+++ b/packages/frontend-bo/src/pages/connexion/index.vue
@@ -201,7 +201,13 @@ async function login() {
       },
     );
     formStatus.value = formStates.SUBMITTED;
-    userStore.user = response.user;
+    const serviceCompetent =
+      response.user.territoireCode === "FRA"
+        ? "NAT"
+        : /^\d+$/.test(response.user.territoireCode)
+          ? "DEP"
+          : "REG";
+    userStore.user = { ...response.user, serviceCompetent };
     toaster.success({
       titleTag: "h2",
       description: `Authentification réalisée avec succès`,


### PR DESCRIPTION
Problème d'affichage du menu Validation des comptes OVA côté BO
Chargement du profil dès la connexion pour éviter d'avoir à faire un refresh du navigateur.