### PR TITLE
fix(bo): affichage volume de message reçu et icone dans le tab

### DIFF
--- a/packages/frontend-bo/src/pages/sejours/[declarationId]/messagerie.vue
+++ b/packages/frontend-bo/src/pages/sejours/[declarationId]/messagerie.vue
@@ -17,8 +17,6 @@ const toaster = useToaster();
 
 const messages = computed(() => demandeSejourStore.messages);
 
-demandeSejourStore.fetchMessages(route.params.declarationId);
-
 const isSendingMessage = ref(false);
 const chatRef = ref(null);
 

--- a/packages/shared/src/components/DsfrTabsItemV2.vue
+++ b/packages/shared/src/components/DsfrTabsItemV2.vue
@@ -48,7 +48,10 @@ function onKeyDown(event: KeyboardEvent) {
       :id="props.tabId"
       ref="button"
       :data-testid="`test-${props.tabId}`"
-      class="fr-tabs__tab"
+      :class="[
+        'fr-tabs__tab',
+        props.icon && `fr-icon-${props.icon} fr-tabs__tab--icon-left`,
+      ]"
       :tabindex="props.selected ? 0 : -1"
       role="tab"
       type="button"

--- a/packages/shared/src/components/DsfrTabsV2.vue
+++ b/packages/shared/src/components/DsfrTabsV2.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
     label: string;
     tabPanelId: string;
     tabId: string;
+    icon?: string;
   }[];
   modelValue: number;
 }>();
@@ -126,6 +127,7 @@ const animationEnd = () => {
         :tab-id="tab.tabId"
         :panel-id="tab.tabPanelId"
         :selected="activeTab === index"
+        :icon="tab.icon"
         @click="selectTab(index)"
         @next="selectNext()"
         @previous="selectPrevious()"


### PR DESCRIPTION
## Tickets liés
Close #
tickets liés : [fix/chat-message-indication-922](https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336/backlog?selectedIssue=VAO-922)

## Description
Ajoute le nombre de messages non lus + une icone dans le label de l'onglet "messagerie" sur l'écran d'une déclaration de séjour coté BO

### dont régressions potentielles à tester

## Screenshot / liens loom 
<img width="1224" alt="Capture d’écran 2025-05-20 à 16 18 46" src="https://github.com/user-attachments/assets/3e4f97a3-dbc1-4518-b664-a517d541d35d" />


## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [x] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`

