### PR TITLE
fix(bo): change route pour download doc

### DIFF
--- a/packages/frontend-bo/src/components/demandes-sejour/eigs.vue
+++ b/packages/frontend-bo/src/components/demandes-sejour/eigs.vue
@@ -13,7 +13,7 @@
         v-if="eigStore.currentEig"
         :eig="eigStore.currentEig"
         :file="eigStore.currentEig?.file"
-        :cdn-url="`${config.public.backendUrl}/documents/`"
+        :cdn-url="`${config.public.backendUrl}/documents/admin/`"
         @update:file="file"
       />
     </DsfrAccordion>

--- a/packages/frontend-bo/src/pages/eig/[eigId].vue
+++ b/packages/frontend-bo/src/pages/eig/[eigId].vue
@@ -2,7 +2,7 @@
   <Synthese
     :eig="eigStore.currentEig ?? {}"
     :file="eigStore.currentEig?.file"
-    :cdn-url="`${config.public.backendUrl}/documents/`"
+    :cdn-url="`${config.public.backendUrl}/documents/admin`"
     @update:file="file"
   />
 </template>

--- a/packages/frontend-bo/src/pages/hebergement/[type]/[demandeSejourId]/[hebergementId].vue
+++ b/packages/frontend-bo/src/pages/hebergement/[type]/[demandeSejourId]/[hebergementId].vue
@@ -3,7 +3,7 @@
     <Hebergement
       :init-hebergement="hebergement"
       is-disabled
-      :cdn-url="`${config.public.backendUrl}/documents/`"
+      :cdn-url="`${config.public.backendUrl}/documents/admin`"
       default-back-route="/hebergements"
     >
       <template #search="scope">

--- a/packages/frontend-bo/src/pages/hebergement/[type]/[hebergementId].vue
+++ b/packages/frontend-bo/src/pages/hebergement/[type]/[hebergementId].vue
@@ -3,7 +3,7 @@
     <Hebergement
       :init-hebergement="hebergement"
       is-disabled
-      :cdn-url="`${config.public.backendUrl}/documents/`"
+      :cdn-url="`${config.public.backendUrl}/documents/admin`"
       default-back-route="/hebergements"
     >
       <template #search="scope">

--- a/packages/frontend-bo/src/pages/sejours/[declarationId]/messagerie.vue
+++ b/packages/frontend-bo/src/pages/sejours/[declarationId]/messagerie.vue
@@ -2,7 +2,7 @@
   <Chat
     ref="chatRef"
     :messages="messages"
-    :cdn-url="`${config.public.backendUrl}/documents/`"
+    :cdn-url="`${config.public.backendUrl}/documents/admin`"
     :is-loading="isSendingMessage"
     @send="sendMessage"
   />


### PR DESCRIPTION
Fix: problème de routes sur le download des documents côté BO
Passage de token qui bloquait sur la route BO (check du jwt frontUsager au lieu de BO)