### PR TITLE
fix(bo): lien messagerie et update version vuedsfr pour corriger une …

### DIFF
--- a/packages/frontend-bo/package.json
+++ b/packages/frontend-bo/package.json
@@ -16,11 +16,11 @@
   },
   "dependencies": {
     "@gouvfr/dsfr": "^1.13.0",
-    "@gouvminint/vue-dsfr": "^8.2.1",
+    "@gouvminint/vue-dsfr": "^8.4.0",
     "@iconify/vue": "^4.3.0",
     "@pinia/nuxt": "~0.5.4",
-    "@sentry/vue": "~8.54.0",
     "@samk-dev/nuxt-vcalendar": "^1.0.4",
+    "@sentry/vue": "~8.54.0",
     "@socialgouv/dsfr-toaster-nuxt-module": "~1.5.0",
     "@vao/shared": "1.0.0",
     "@vee-validate/i18n": "~4.13.0",

--- a/packages/frontend-bo/src/components/demandes-sejour/ListByMessage.vue
+++ b/packages/frontend-bo/src/components/demandes-sejour/ListByMessage.vue
@@ -30,8 +30,16 @@
     <template #cell-messageLastAt="{ cell }">
       {{ displayDateHours(cell) }}
     </template>
-    <template #cell-message="{ cell }">
-      <span> <MessageHover v-if="cell" :content="cell" /> </span>
+    <template #cell-message="{ cell, row }">
+      <NuxtLink
+        :to="`/sejours/${row.declarationId}/messagerie`"
+        title="Naviguer vers la messagerie"
+        class="no-background-image"
+      >
+        <span>
+          <MessageHover v-if="cell" :content="cell" />
+        </span>
+      </NuxtLink>
     </template>
     <template #cell-messageEtat="{ row, cell }">
       <MessageEtat :message="row.message" :etat="cell" />
@@ -39,7 +47,7 @@
     <template #cell-custom:edit="{ row }">
       <NuxtLink
         :to="`/sejours/${row.declarationId}/messagerie`"
-        title="Naviguer vers la demande séjour"
+        title="Naviguer vers la messagerie"
         class="no-background-image"
       >
         <DsfrButton

--- a/packages/frontend-usagers/package.json
+++ b/packages/frontend-usagers/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@gouvfr/dsfr": "^1.13.0",
-    "@gouvminint/vue-dsfr": "^8.2.1",
+    "@gouvminint/vue-dsfr": "^8.4.0",
     "@iconify/vue": "^4.3.0",
     "@pinia/nuxt": "~0.5.4",
     "@samk-dev/nuxt-vcalendar": "^1.0.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,13 +12,13 @@
   "description": "",
   "dependencies": {
     "@gouvfr/dsfr": "^1.13.0",
-    "@gouvminint/vue-dsfr": "^8.2.1",
+    "@gouvminint/vue-dsfr": "^8.4.0",
     "@iconify/vue": "^4.3.0",
-    "@vao/shared": "^1.0.0",
     "@socialgouv/dsfr-toaster-nuxt-module": "~1.5.0",
+    "@vao/shared": "^1.0.0",
     "@vueform/multiselect": "~2.6.7",
-    "debug": "~4.3.4",
     "dayjs": "^1.11.11",
+    "debug": "~4.3.4",
     "vee-validate": "~4.13.0",
     "vue": "latest",
     "yup": "~1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,6 +2139,17 @@
     vue "^3.5.13"
     vue-router "^4.5.0"
 
+"@gouvminint/vue-dsfr@^8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@gouvminint/vue-dsfr/-/vue-dsfr-8.4.0.tgz#f1a965e8fa65e7df03c142d1916413c1ae0f5228"
+  integrity sha512-PyFnA9REL6ZYjPyxfF1kRw53nr8ANT/m67qPPG/lAExvbT7yq7xwHtGRALPJquDKHmb+QXUwpyWuaDD7IJnbKw==
+  dependencies:
+    "@gouvfr/dsfr" "~1.13.0"
+    focus-trap "^7.6.4"
+    focus-trap-vue "^4.0.3"
+    vue "^3.5.13"
+    vue-router "^4.5.0"
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"


### PR DESCRIPTION
…erreur js (#976)

## Ticket(s) lié(s)
976

## Description
ajoute le lien vers les messages et corrige une erreur js sur la tooltip en upgradant la version du vueDsfr. 

### Dont régressions potentielles à tester
Pas de regressions notées de mon coté mais la montée de version du vue dsfr impacte les composants suivants:
-DsfrTag
-DsfrHeader
-DsfrDataTable
-DsfrTabs

## Screenshot / liens loom 

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

