### PR TITLE
Create doc_produit

### DIFF
--- a/doc_produit
+++ b/doc_produit
@@ -1,0 +1,6 @@
+# Summary
+
+- [Accueil](README.md)
+- [Contexte](contexte.md)
+- [Vision produit](vision.md)
+- [Gouvernance](gouvernance.md)


### PR DESCRIPTION
Création d'un dossier doc-produit pour rassembler la documentation produit dans le repo. 
Liaison avec Gitbook pour générer un site de documentation (à faire, pas lié à cette PR). 

Je pense qu'on peut définir que ce dossier /doc-produit peut-être skip pour les tests. 