### PR TITLE
docs: Create doc_produit folder

### DIFF
--- a/doc_produit/README.md
+++ b/doc_produit/README.md
@@ -1,0 +1,3 @@
+- [Contexte](contexte.md)
+- [Vision produit](vision.md)
+- [Gouvernance](gouvernance.md)


### PR DESCRIPTION
Création d'un dossier doc-produit pour rassembler la documentation produit dans le repo.
Liaison avec Gitbook pour générer un site de documentation (à faire, pas lié à cette PR).

Je pense qu'on peut définir que ce dossier /doc-produit peut-être skip pour les tests.