### PR TITLE
feat(fusager): désactivation bouton supprimé pour etab secondaire 989

### DIFF
--- a/packages/frontend-usagers/src/components/demande-sejour/table.vue
+++ b/packages/frontend-usagers/src/components/demande-sejour/table.vue
@@ -62,7 +62,10 @@
           size="small"
           type="button"
           :label="row.statut === draftStatus ? 'Supprimer' : 'Annuler'"
-          :disabled="!enabledDeleteCancelStatus.includes(row.statut)"
+          :disabled="
+            !enabledDeleteCancelStatus.includes(row.statut) ||
+            userStore.user?.siret !== row.siret
+          "
           @click="handleRemoveClose(row.declarationId, row.statut)"
         />
         <DsfrButton
@@ -111,6 +114,7 @@ const route = useRoute();
 const demandeSejourStore = useDemandeSejourStore();
 const departementStore = useDepartementStore();
 const toaster = useToaster();
+const userStore = useUserStore();
 
 const data = computed(() => demandeSejourStore.demandes);
 const total = computed(() => demandeSejourStore.totalDemandes);


### PR DESCRIPTION
## Ticket(s) lié(s)
989

## Description
On désactive le bouton Supprimer lorsque ce n'est pas mon établissement (donc les établissements secondaires)
La désactivation n'était déjà pas possible (déjà contrôlé côté backend) il s'agissait juste de griser le bouton.

## Check-list

 - [X] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [ ] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

