### PR TITLE
fix: liens evitements fonctionnels sur toutes les pages(1008)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,7 +1,8 @@
 fileignoreconfig:
-- filename: .kontinuous/env/preprod/templates/smtp/deployment.yaml
-  checksum: e05745b618cdfe033bd27bb7baffa0c77024de76b79fcd346f2ab33c5530fac0
-- filename: .kontinuous/env/preprod/templates/smtp/ingress.yaml
+- filename: packages/shared/src/components/Skiplinks.vue
+  checksum: 88d146421ae61b6a7c6e37fac9bd53768629aa443132d9ee233fb52d594165e0
+version: ""
+filename: .kontinuous/env/preprod/templates/smtp/ingress.yaml
   checksum: 2414a3f1746ccd11cbb12b86dd2bb4a16cbc5bd6fe1450c308579972128176e6
 - filename: .kontinuous/env/preprod/templates/token.sealed.secret.yaml
   checksum: 4aaab89fff588b5c4098042f6c8945a65eb30c6384d3b3aa35225611fa005b7e

--- a/packages/frontend-bo/src/layouts/default.vue
+++ b/packages/frontend-bo/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Header, Footer, useLayoutHeader } from "@vao/shared";
+import { Header, Footer, Skiplinks, useLayoutHeader } from "@vao/shared";
 
 const navItems = useMenuNavItems();
 const userStore = useUserStore();
@@ -23,21 +23,7 @@ function acceptAll() {
 <template>
   <div>
     <DsfrToaster />
-    <div class="fr-skiplinks">
-      <nav class="fr-container" role="navigation" aria-label="Accès rapide">
-        <ul class="fr-skiplinks__list" role="list">
-          <li role="listitem">
-            <a class="fr-link" href="#menu">Menu</a>
-          </li>
-          <li role="listitem">
-            <a class="fr-link" href="#content">Contenu</a>
-          </li>
-          <li role="listitem">
-            <a class="fr-link" href="#footer">Pied de page</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <Skiplinks />
     <div class="fr-container">
       <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12">

--- a/packages/frontend-usagers/src/layouts/default.vue
+++ b/packages/frontend-usagers/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Header, Footer, useLayoutHeader } from "@vao/shared";
+import { Header, Footer, Skiplinks, useLayoutHeader } from "@vao/shared";
 
 const userStore = useUserStore();
 const config = useRuntimeConfig();
@@ -24,21 +24,7 @@ const navItems = useMenuNavItems();
 <template>
   <div>
     <DsfrToaster />
-    <div class="fr-skiplinks">
-      <nav class="fr-container" role="navigation" aria-label="Accès rapide">
-        <ul class="fr-skiplinks__list" role="list">
-          <li role="listitem">
-            <a class="fr-link" href="#menu">Menu</a>
-          </li>
-          <li role="listitem">
-            <a class="fr-link" href="#content">Contenu</a>
-          </li>
-          <li role="listitem">
-            <a class="fr-link" href="#footer">Pied de page</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <Skiplinks />
     <Header
       :home-to="homeTo"
       :quick-links="quickLinks"

--- a/packages/shared/src/components/Skiplinks.vue
+++ b/packages/shared/src/components/Skiplinks.vue
@@ -1,0 +1,87 @@
+<script setup>
+import { useRoute } from "#imports";
+
+let removeFirstTabListener = null;
+let skipLinksDisabled = false;
+
+onUnmounted(() => {
+  if (removeFirstTabListener) removeFirstTabListener();
+});
+
+function setupSkipLinkFocus() {
+  if (removeFirstTabListener) removeFirstTabListener();
+
+  skipLinksDisabled = false;
+
+  let handled = false;
+
+  function onFirstTab(e) {
+    if (!handled && e.key === "Tab" && !skipLinksDisabled) {
+      e.preventDefault();
+      const skipLink = document.querySelector(".fr-skiplinks a");
+
+      if (skipLink) {
+        skipLink.focus();
+        handled = true;
+        document.removeEventListener("keydown", onFirstTab);
+      }
+    }
+  }
+
+  handled = false;
+  document.addEventListener("keydown", onFirstTab);
+
+  removeFirstTabListener = () =>
+    document.removeEventListener("keydown", onFirstTab);
+
+  document.querySelectorAll(".fr-skiplinks a").forEach((link) => {
+    const existingHandler = link._skipLinkHandler;
+
+    if (existingHandler) {
+      link.removeEventListener("click", existingHandler);
+    }
+
+    const clickHandler = (e) => {
+      e.preventDefault();
+      const targetId = link.getAttribute("href")?.replace("#", "");
+      if (targetId) {
+        const target = document.getElementById(targetId);
+        if (target) {
+          nextTick(() => {
+            target.setAttribute("tabindex", "-1");
+            target.focus();
+            skipLinksDisabled = true;
+            removeFirstTabListener();
+          });
+        }
+      }
+    };
+
+    link._skipLinkHandler = clickHandler;
+    link.addEventListener("click", clickHandler);
+  });
+}
+
+const route = useRoute();
+onMounted(setupSkipLinkFocus);
+
+watch(() => route.path, setupSkipLinkFocus);
+</script>
+
+<template>
+  <div class="fr-skiplinks">
+    <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+      <ul class="fr-skiplinks__list">
+        <li>
+          <a class="fr-link" href="#menu">Menu</a>
+        </li>
+        <li>
+          <a class="fr-link" href="#content">Contenu</a>
+        </li>
+        <li>
+          <a class="fr-link" href="#footer">Pied de page</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>

--- a/packages/shared/src/components/index.js
+++ b/packages/shared/src/components/index.js
@@ -29,6 +29,7 @@ import RefusCompteModal from "./users/RefusCompteModal.vue";
 import Header from "./Header.vue";
 import Footer from "./Footer.vue";
 import ErrorPage from "./ErrorPage.vue";
+import Skiplinks from "./Skiplinks.vue";
 export {
   ApiUnavailable,
   FileUpload,
@@ -61,4 +62,5 @@ export {
   Header,
   Footer,
   ErrorPage,
+  Skiplinks,
 };


### PR DESCRIPTION
## Ticket(s) lié(s)
[fix/liens-evitement-1008](https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336/backlog?selectedIssue=VAO-1008)

## Description
Fais en sorte d'avoir les liens d'evitement sur toutes les pages. Actuellement le focus ne se reset pas quand on change de page

### Dont régressions potentielles à tester

## Screenshot / liens loom 

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [x] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

