### PR TITLE
fix(checkjwt): token not found on rotation - user deconnexion

### DIFF
--- a/packages/backend/src/middlewares/common/checkJWT.js
+++ b/packages/backend/src/middlewares/common/checkJWT.js
@@ -165,7 +165,7 @@ async function checkJWT(req, res, next, targetSchema) {
       );
     }
 
-    const user = getUserBySchema(targetSchema, rtDecoded.userId);
+    const user = await getUserBySchema(targetSchema, rtDecoded.userId);
     const { buildAccessToken, buildRefreshToken } =
       getTokenBuilders(targetSchema);
     const newAccessTokenPayload = buildAccessToken(user);


### PR DESCRIPTION
Deconnexion utilisateur à la rotation du token au bout de 30 minutes
Potentiellement aléatoire