### PR TITLE
fix: affiche numero DS a la place du statut [page DS] (1027)

### DIFF
--- a/packages/frontend-usagers/src/pages/demande-sejour/[[declarationId]].vue
+++ b/packages/frontend-usagers/src/pages/demande-sejour/[[declarationId]].vue
@@ -505,7 +505,7 @@ const demandeDetails = computed(() => {
     },
     {
       label: "Déclaration",
-      value: demandeCourante.value.statut,
+      value: demandeCourante.value.idFonctionnelle,
     },
   ];
 });


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336/backlog?selectedIssue=VAO-1027

## Description
Affiche le numero DS à la place du statut sur la page d'une DS

### Dont régressions potentielles à tester

## Screenshot / liens loom 

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

