### PR TITLE
fix/ova-account-can-blocked-other-without-role-rw-1012

### DIFF
--- a/packages/frontend-usagers/src/components/user/Compte.vue
+++ b/packages/frontend-usagers/src/components/user/Compte.vue
@@ -69,7 +69,6 @@
           <div>
             <div class="buttons-group">
               <DsfrButton
-                v-if="canUpdate"
                 :disabled="!roleEigMeta.valid"
                 label="Enregistrer"
                 @click.prevent="update"
@@ -114,11 +113,11 @@ const log = logger("pages/comptes/");
 const usersStore = useUserStore();
 const toaster = useToaster();
 
-const canUpdate = computed(() =>
-  usersStore.user.roles.includes(rolesUtil.EIG_ECRITURE),
+const canUpdateRole = computed(() =>
+  usersStore.user?.roles?.includes(rolesUtil.EIG_ECRITURE)
+    ? isActive.value
+    : false,
 );
-
-const canUpdateRole = computed(() => canUpdate && isActive.value);
 
 const roleOptions = [
   {
@@ -218,7 +217,10 @@ async function update() {
       const params = { status: statut.value };
       await usersStore.changeUserStatus(props.user.userId, params);
     }
-    if (statut.value === statusUser.status.VALIDATED) {
+    if (
+      usersStore.user.roles.includes(rolesUtil.EIG_ECRITURE) &&
+      statut.value === statusUser.status.VALIDATED
+    ) {
       log.d("update : update roles");
       await usersStore.updateRole({
         roles: roleEig.value,


### PR DESCRIPTION
## Ticket(s) lié(s)
1012
## Description
Modification de la possibilité de désactivation d'un compte.
On ne bloque plus les enregistrements lorsque l'utilisateur n'a pas les droits de lecture écriture EIG. 

L'utilisateur ne pouvait pas désactiver un autre utilisateur s'il n'avait pas les droits de lecture écriture EIG

