### PR TITLE
fix: tri des tableau liste comptes organisateurs (1088)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: packages/backend/src/services/FoUser.js
-  checksum: 80b3a2679375a0bb7829c239602495aa7b6078d2cf7bb98d6bb9a62227865e27
+  checksum: c772592923b313b62e6ae80354850ceab3bdbcdae5938556de3d1c0233582a09
 version: ""
 : ""
 filename: .kontinuous/env/preprod/templates/smtp/ingress.yaml

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,7 +1,8 @@
 fileignoreconfig:
-- filename: packages/shared/src/components/Skiplinks.vue
-  checksum: 88d146421ae61b6a7c6e37fac9bd53768629aa443132d9ee233fb52d594165e0
+- filename: packages/backend/src/services/FoUser.js
+  checksum: 80b3a2679375a0bb7829c239602495aa7b6078d2cf7bb98d6bb9a62227865e27
 version: ""
+: ""
 filename: .kontinuous/env/preprod/templates/smtp/ingress.yaml
   checksum: 2414a3f1746ccd11cbb12b86dd2bb4a16cbc5bd6fe1450c308579972128176e6
 - filename: .kontinuous/env/preprod/templates/token.sealed.secret.yaml

--- a/packages/backend/src/controllers/fo-user/list.js
+++ b/packages/backend/src/controllers/fo-user/list.js
@@ -38,6 +38,10 @@ module.exports = async function list(req, res, next) {
         abortEarly: false,
       },
     );
+    if (typeof params.search === "object") {
+      params = { ...params, ...params.search };
+      delete params.search;
+    }
   } catch (error) {
     return next(new ValidationAppError(error));
   }

--- a/packages/backend/src/helpers/queryParams.js
+++ b/packages/backend/src/helpers/queryParams.js
@@ -113,7 +113,7 @@ const applyFilters = (query, initialParams, filters, groupBy = "") => {
     .filter(Boolean)
     .join(" AND ");
 
-  let newQuery = `${query} AND ${filteringQuery}`;
+  let newQuery = filteringQuery ? `${query} AND ${filteringQuery}` : query;
   if (groupBy) {
     newQuery += `\n${groupBy}\n`;
   }
@@ -159,17 +159,22 @@ const processQuery = (
   titles,
   queryParams,
   defaultSort = {},
+  groupBy = null,
 ) => {
   const filterParams = sanitizeFiltersParams(queryParams, titles);
   const baseQuery = queryBuilder();
   const filteredQuery = applyFilters(baseQuery, baseParams, filterParams);
+  let queryWithGroupBy = filteredQuery.query;
+  if (groupBy) {
+    queryWithGroupBy += `\nGROUP BY ${groupBy}`;
+  }
   const { limit, offset, sort } = sanitizePaginationParams(
     queryParams,
     titles,
     defaultSort,
   );
   return applyPagination(
-    filteredQuery.query,
+    queryWithGroupBy,
     filteredQuery.params,
     limit,
     offset,

--- a/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
+++ b/packages/frontend-bo/src/pages/comptes/liste-organisme.vue
@@ -16,7 +16,7 @@
                   label="Nom"
                   placeholder="Nom"
                   :label-visible="true"
-                  @update:model-value="updateData"
+                  @update:model-value="updateDataDebounced"
                 />
               </div>
             </div>
@@ -31,7 +31,7 @@
                   label="Prénom"
                   placeholder="Prénom"
                   :label-visible="true"
-                  @update:model-value="updateData"
+                  @update:model-value="updateDataDebounced"
                 />
               </div>
             </div>
@@ -46,7 +46,7 @@
                   label="Adresse courriel"
                   placeholder="Adresse courriel"
                   :label-visible="true"
-                  @update:model-value="updateData"
+                  @update:model-value="updateDataDebounced"
                 />
               </div>
             </div>
@@ -61,7 +61,7 @@
                   label="Organisme"
                   placeholder="Organisme"
                   :label-visible="true"
-                  @update:model-value="updateData"
+                  @update:model-value="updateDataDebounced"
                 />
               </div>
             </div>
@@ -80,7 +80,7 @@
       :total="usersStore.totalUsersFO"
       row-id="organismeId"
       is-sortable
-      @update-data="updateData"
+      @update-data="updateDataImmediate"
     >
       <template #cell-statut="{ cell }">
         {{ mapStatutToLabel(cell) }}
@@ -231,34 +231,45 @@ const isValidParams = (params) =>
   (!Array.isArray(params) || params.length > 0);
 
 let timeout = null;
-const updateData = () => {
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  timeout = setTimeout(() => {
-    const query = {
+
+const fetchAndNavigate = () => {
+  const query = {
+    limit: limit.value,
+    offset: offset.value,
+    ...(isValidParams(sort.value) ? { sortBy: sort.value } : {}),
+    ...(isValidParams(sortDirection.value)
+      ? { sortDirection: sortDirection.value.toUpperCase() }
+      : {}),
+    search: searchState,
+  };
+
+  usersStore.fetchUsersOrganisme(query);
+  navigateTo({
+    query: {
       limit: limit.value,
       offset: offset.value,
       ...(isValidParams(sort.value) ? { sortBy: sort.value } : {}),
       ...(isValidParams(sortDirection.value)
-        ? { sortDirection: sortDirection.value.toUpperCase() }
+        ? { sortDirection: sortDirection.value }
         : {}),
-      search: searchState,
-    };
+      ...searchState,
+    },
+  });
+};
 
-    usersStore.fetchUsersOrganisme(query);
-    navigateTo({
-      query: {
-        limit: limit.value,
-        offset: offset.value,
-        ...(isValidParams(sort.value) ? { sortBy: sort.value } : {}),
-        ...(isValidParams(sortDirection.value)
-          ? { sortDirection: sortDirection.value }
-          : {}),
-        ...searchState,
-      },
-    });
-  }, 300);
+const updateDataImmediate = () => {
+  if (timeout) {
+    clearTimeout(timeout);
+    timeout = null;
+  }
+  fetchAndNavigate();
+};
+
+const updateDataDebounced = () => {
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  timeout = setTimeout(fetchAndNavigate, 300);
 };
 
 onUnmounted(() => {


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336?selectedIssue=VAO-1088

## Description
Correction du tri tableau de la liste des comptes organisateurs. Refactoring du service lié en utilisant le helper processQuery. En front suppression du debounce sur le tri des tableaux. Le debounce est conservé uniquement pour les filtres sous la forme de text inputs.

J'ai galéré avec le GROUP BY qui s'appliquait avant les filtres ajoutés. Du coup en l'état je gère le GROUP BY dans le service. Est ce que ça serait mieux de modifier le helper "processQuery" pour qu'il prenne un param groupBy et qu'il l'ajoute au bon endroit ? 

### Dont régressions potentielles à tester

## Screenshot / liens loom 

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [x] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

