### PR TITLE
fix(eig): correction région agrement null 1051

### DIFF
--- a/packages/backend/src/services/eig.js
+++ b/packages/backend/src/services/eig.js
@@ -70,11 +70,32 @@ const query = {
     pp.prenom AS "prenom",
     pp.nom_usage AS "nom",
     ARRAY_AGG(ET.TYPE) as "types",
-    AGR.region_obtention as "agrementRegionObtention",
+    CASE
+      WHEN o.type_organisme = 'personne_morale' AND pm.porteur_agrement::boolean is False
+      THEN
+      (
+          SELECT
+            region_obtention
+          FROM front.agrements a
+          JOIN front.organismes o2 ON o2.id = a.organisme_id
+          INNER JOIN front.personne_morale pm2 ON pm2.organisme_id = o2.id
+          INNER JOIN front.opm_etablissements etab ON etab.personne_morale_id = pm2.id
+          WHERE pm.siret = etab.siret
+          AND a.supprime = false
+      )
+      ELSE (
+        SELECT
+            region_obtention
+        FROM front.agrements a
+        WHERE organisme_id = o.id
+        AND a.supprime = false
+      )
+    END AS "agrementRegionObtention",
     EIG.file
   FROM
     FRONT.EIG EIG
     INNER JOIN FRONT.USER_ORGANISME UO ON EIG.USER_ID = UO.USE_ID
+    INNER JOIN FRONT.organismes o ON uo.org_id = o.id
     LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID
     LEFT JOIN FRONT.EIG_TO_EIG_TYPE E2ET ON E2ET.EIG_ID = EIG.ID
     LEFT JOIN FRONT.EIG_TYPE ET ON ET.ID = E2ET.EIG_TYPE_ID
@@ -87,6 +108,7 @@ const query = {
     ${search}
   GROUP BY
     EIG.ID,
+    o.id,
     S.ID,
     DS.ID,
     AGR.ID,
@@ -155,9 +177,30 @@ const query = {
       EIG.IS_ATTESTE as "isAtteste",
       EIG.PERSONNEL as "personnel",
       EIG.EMAIL_AUTRES_DESTINATAIRES as "emailAutresDestinataires",
-      AGR.region_obtention as "agrementRegionObtention"
+      CASE
+        WHEN o.type_organisme = 'personne_morale' AND pm.porteur_agrement::boolean is False
+        THEN
+        (
+            SELECT
+              region_obtention
+            FROM front.agrements a
+            JOIN front.organismes o2 ON o2.id = a.organisme_id
+            INNER JOIN front.personne_morale pm2 ON pm2.organisme_id = o2.id
+            INNER JOIN front.opm_etablissements etab ON etab.personne_morale_id = pm2.id
+            WHERE pm.siret = etab.siret
+            AND a.supprime = false
+        )
+        ELSE (
+          SELECT
+              region_obtention
+          FROM front.agrements a
+          WHERE organisme_id = o.id
+          AND a.supprime = false
+        )
+      END AS "agrementRegionObtention"
     FROM FRONT.EIG EIG
         INNER JOIN FRONT.USER_ORGANISME UO ON EIG.USER_ID = UO.USE_ID
+        INNER JOIN FRONT.organismes o ON uo.org_id = o.id
         LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID
         LEFT JOIN FRONT.EIG_TO_EIG_TYPE E2ET ON E2ET.EIG_ID = EIG.ID
         LEFT JOIN FRONT.EIG_TYPE ET ON ET.ID = E2ET.EIG_TYPE_ID
@@ -170,6 +213,7 @@ const query = {
       EIG.ID = $1
     GROUP BY
       EIG.ID,
+      o.id,
       S.ID,
       DS.ID,
       AGR.ID,


### PR DESCRIPTION
## Ticket(s) lié(s)
1051

## Description
La région de l'agrément d'un EIG restait null lorsque l'agrément était celui de l'organisme principal.
Modification des requêtes pour que la DR puisse prendre en charge dans ce cas.

### Dont régressions potentielles à tester
EIG

## Check-list

 - [X] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié

