### PR TITLE
fix(bo): default sort correction 1111

### DIFF
--- a/packages/backend/src/helpers/__tests__/queryParams.test.js
+++ b/packages/backend/src/helpers/__tests__/queryParams.test.js
@@ -130,7 +130,7 @@ describe("queryParams", () => {
     expect(result).toEqual({
       limit: 20,
       offset: 5,
-      sort: "ORDER BY LOWER(name::varchar) ASC",
+      sort: "ORDER BY LOWER(unaccent(name::varchar)) ASC",
     });
   });
 

--- a/packages/backend/src/helpers/queryParams.js
+++ b/packages/backend/src/helpers/queryParams.js
@@ -1,16 +1,16 @@
 const getSort = (sortBy, direction, titles, defaultSort = "") => {
-  if (sortBy && direction) {
-    const title = titles.find((t) => t.queryKey === sortBy && t.sortEnabled);
-    if (title) {
-      if (title.customSort) {
-        return title.customSort(sortBy, direction);
-      }
-      if (title?.sortType === "date") {
-        return `ORDER BY ${title.sortQuery ?? title.key} ${direction}`;
-      }
-      return `ORDER BY LOWER(${title.sortQuery ?? title.key}::varchar) ${direction}`;
+  const finalSortBy = sortBy || defaultSort;
+  if (finalSortBy && direction) {
+    const title = titles.find(
+      (t) => t.queryKey === finalSortBy && t.sortEnabled,
+    );
+    if (title?.customSort) {
+      return title.customSort(finalSortBy, direction);
     }
-    return `ORDER BY LOWER(${defaultSort}::varchar) ${direction}`;
+    if (title?.sortType === "date") {
+      return `ORDER BY ${title.sortQuery ?? title.key} ${direction}`;
+    }
+    return `ORDER BY LOWER(unaccent(${title.sortQuery ?? title.key}::varchar)) ${direction}`;
   }
   return "";
 };

--- a/packages/backend/src/services/Territoire.js
+++ b/packages/backend/src/services/Territoire.js
@@ -102,8 +102,15 @@ module.exports.fetch = async (queryParams) => {
       type: "default",
     },
   ];
+  const { limit, offset, sort } = sanitizePaginationParams(
+    queryParams,
+    titles,
+    {
+      sortBy: "label",
+      sortDirection: "ASC",
+    },
+  );
 
-  const { limit, offset, sort } = sanitizePaginationParams(queryParams, titles);
   const filterParams = sanitizeFiltersParams(queryParams, titles);
 
   const queryGet = query.select();


### PR DESCRIPTION
## Ticket(s) lié(s)
1111
## Description
Mise en place d'un tri par défaut sur le label pour les territoires
Correction de la fonction getSort qui ne prennait pas le tri par défaut
