### PR TITLE
fix(ds): fo empty list

### DIFF
--- a/packages/backend/src/helpers/queryParams.js
+++ b/packages/backend/src/helpers/queryParams.js
@@ -4,6 +4,9 @@ const getSort = (sortBy, direction, titles, defaultSort = "") => {
     const title = titles.find(
       (t) => t.queryKey === finalSortBy && t.sortEnabled,
     );
+    if (!title) {
+      return "";
+    }
     if (title?.customSort) {
       return title.customSort(finalSortBy, direction);
     }


### PR DESCRIPTION
## Ticket(s) lié(s)
Aucun
## Description
Régression sur le tri des listes par défaut suis à review. 
La liste restait vide pour la déclaration des séjours côté BO