### PR TITLE
fix: 1025 - DatePicker en double champ 

### DIFF
--- a/packages/frontend-usagers/src/pages/eig/liste.vue
+++ b/packages/frontend-usagers/src/pages/eig/liste.vue
@@ -68,10 +68,22 @@
             <div
               class="fr-fieldset__element fr-fieldset__element--inline fr-col-12 fr-col-md-3 fr-col-lg-2"
             >
-              <RangeDatePicker
-                v-model="searchState.dateRange"
-                label="Date de l'eig"
-              />
+              <div class="fr-input-group">
+                EIG entre le :
+                <DsfrInputGroup
+                  v-model="searchState.dateRange.start"
+                  type="date"
+                  label="Date de début"
+                />
+              </div>
+              <div class="fr-input-group">
+                et le :
+                <DsfrInputGroup
+                  v-model="searchState.dateRange.end"
+                  type="date"
+                  label="Date de fin"
+                />
+              </div>
             </div>
           </div>
         </form>
@@ -118,7 +130,6 @@ import EigStatusBadge from "@vao/shared-ui/src/components/eig/EigStatusBadge.vue
 import {
   eigModel,
   EigTypeListe,
-  RangeDatePicker,
   TableWithBackendPagination,
   ValidationModal,
 } from "@vao/shared-ui";
@@ -152,7 +163,7 @@ const searchState = reactive({
   statut: null,
   idFonctionnelle: null,
   type: null,
-  dateRange: null,
+  dateRange: { start: new Date(), end: new Date() },
 });
 
 const paginateResults = async (sortValue, limitValue, currentPageValue) => {


### PR DESCRIPTION
## Ticket(s) lié(s)
1025
## Description
Transformation du DatePicker en double champ de saisie.
Pas de correction fiable trouvée. Mise en place d'un contournement

TODO : Côté Back, prévoir des date de début vide ou date de fin vide pour ne pas donner de résultat vide ou incohérent