### PR TITLE
fix: 1330 bo filter list ds from organisation

### DIFF
--- a/packages/backend/src/services/DemandeSejour.js
+++ b/packages/backend/src/services/DemandeSejour.js
@@ -1324,7 +1324,7 @@ module.exports.getByDepartementCodes = async (
       key: "o.id",
       queryKey: "organismeId",
       sortEnabled: true,
-      type: "number",
+      type: "default",
     },
     {
       key: "id_fonctionnelle",


### PR DESCRIPTION
## Ticket(s) lié(s)
1330
## Description
Côté BO la liste des demandes de séjours associées à un organisme PersonnePhysique revenait sans aucun filtrage
Correction : restriction du retour sur l'organisme concerné

## Screenshot / liens loom 

## Check-list

 - [X] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

Sur un compte BO qui gère un organisme Personne Physique qui possède des déclarations de séjour
Aller dans le menu "Organisme"
Filtrer sur la personne physique
Cliquer sur le bouton action >
Cliquer sur l'onglet "Déclaration de séjours"
Avant : Affichait toutes les déclarations de séjour du territoire de l'utilisateur connecté
Maintenant : Affiche toutes les déclarations de séjours du territoire pour l'organisme sélectionné