### PR TITLE
fix: 1334 fusage ova second account to valid disapear

### DIFF
--- a/packages/backend/src/services/FoUser.js
+++ b/packages/backend/src/services/FoUser.js
@@ -306,11 +306,7 @@ module.exports.getByOrganismeId = async (organismesId, queryParams) => {
     offset,
     sort,
   );
-  console.log(
-    "paginatedQuery.query, paginatedQuery.params",
-    paginatedQuery.query,
-    paginatedQuery.params,
-  );
+
   const result = await Promise.all([
     getPool().query(paginatedQuery.query, paginatedQuery.params),
     getPool().query(paginatedQuery.countQuery, paginatedQuery.countQueryParams),

--- a/packages/backend/src/services/FoUser.js
+++ b/packages/backend/src/services/FoUser.js
@@ -84,23 +84,28 @@ const query = {
         CASE 
           WHEN NULLIF(pp.id, 0) IS NOT NULL THEN 
             pp.adresse_siege_label
-          ELSE (
-            SELECT pm4.adresse
+          ELSE 
+          (
+            SELECT pm4.adresse 
               FROM front.personne_morale pm4
               WHERE pm4.siret = COALESCE(u.siret, pm.siret)
               AND pm4."current" = true
-              LIMIT 1
-            )
+            UNION
+		        SELECT '- ' || eta.code_postal || ' ' || eta.commune 
+              FROM front.opm_etablissements eta 
+              WHERE eta.siret = COALESCE(u.siret, pm.siret)
+            LIMIT 1
+          )
         END AS "Adresse"
       FROM front.users AS u
         LEFT JOIN front.user_organisme uo ON uo.use_id = u.id
         LEFT JOIN front.personne_morale pm ON pm.organisme_id = uo.org_id AND pm."current" = true
         LEFT JOIN front.personne_physique pp ON pp.organisme_id = uo.org_id AND pp."current" = true
       WHERE (uo.org_id = ANY ($1) OR 
-        u.siret IN (
-          SELECT siret 
+        substr(u.siret,1,9) IN (
+          SELECT siren 
           FROM front.personne_morale pm2 
-          WHERE pm2.siret = u.siret 
+          WHERE pm2.siren = substr(u.siret,1,9) 
           AND pm2.organisme_id = ANY ($1) 
           AND pm2."current" = true))
       ) AS r
@@ -301,7 +306,11 @@ module.exports.getByOrganismeId = async (organismesId, queryParams) => {
     offset,
     sort,
   );
-
+  console.log(
+    "paginatedQuery.query, paginatedQuery.params",
+    paginatedQuery.query,
+    paginatedQuery.params,
+  );
   const result = await Promise.all([
     getPool().query(paginatedQuery.query, paginatedQuery.params),
     getPool().query(paginatedQuery.countQuery, paginatedQuery.countQueryParams),

--- a/packages/frontend-usagers/src/components/user/liste.vue
+++ b/packages/frontend-usagers/src/components/user/liste.vue
@@ -220,13 +220,18 @@ const updateData = (resetOffset = false) => {
 };
 
 const getCommuneCp = (adresse) => {
-  const decomposeAdresse = adresse.split(" ");
-  const cpIndex = decomposeAdresse.findIndex((mot) =>
-    regex.formatCommuneCP.test(mot),
-  );
-  return cpIndex > 0
-    ? `${decomposeAdresse.slice(cpIndex + 1).join(" ")} (${decomposeAdresse[cpIndex]})`
-    : null;
+  try {
+    const decomposeAdresse = adresse.split(" ");
+    const cpIndex = decomposeAdresse.findIndex((mot) =>
+      regex.formatCommuneCP.test(mot),
+    );
+    return cpIndex > 0
+      ? `${decomposeAdresse.slice(cpIndex + 1).join(" ")} (${decomposeAdresse[cpIndex]})`
+      : null;
+  } catch (e) {
+    log.error("Error while decomposing address", e);
+    return "";
+  }
 };
 updateData();
 


### PR DESCRIPTION
## Ticket(s) lié(s)
1334

## Description
Les comptes OVA secondaires à valider n'apparaissaient plus dans la liste des utilisateurs à valider. 
Amélioration au passage de la récupération de l'adresse

## Screenshot / liens loom 
Avant : 
<img width="1309" height="612" alt="image" src="https://github.com/user-attachments/assets/2fa6539b-5d0e-4dbc-a54d-b35309521804" />
Après
<img width="1205" height="298" alt="image" src="https://github.com/user-attachments/assets/09f043fe-c50a-4e4b-acfc-896239d2db67" />

## Check-list

 - [X] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

Pré-requis : Avoir un compte OVA principal validé
Séquence : 
    Je créé un compte avec un siret d’un établissement secondaire
    Je valide mon email dans la messagerie
Connecté avec un compte sur l’OVA Siège social dans le menu Organisateurs puis Liste des utilisateurs 
Je dois voir : 
    Mon compte OVA principal
    Le compte OVA secondaire à valider