### PR TITLE
fix: 1358 - toaster usagers

### DIFF
--- a/packages/frontend-usagers/src/layouts/default.vue
+++ b/packages/frontend-usagers/src/layouts/default.vue
@@ -1,8 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import {
   Header,
   Footer,
   Skiplinks,
+  Toaster,
   useLayoutHeader,
   useToaster,
 } from "@vao/shared-ui";
@@ -31,7 +32,7 @@ watchEffect(async () => {
       toaster.error({
         titleTag: "h2",
         title: "Erreur lors du chargement de l'agrément",
-        description: e?.message,
+        description: (e as Error)?.message,
       });
       console.error("Erreur lors de la récupération de l'agrément :", e);
     }
@@ -52,7 +53,6 @@ const navItems = useMenuNavItems();
 <template>
   <div>
     <Toaster />
-    <!-- <DsfrToaster /> -->
     <Skiplinks />
     <Header
       :home-to="homeTo"


### PR DESCRIPTION
## Ticket(s) lié(s)

https://jira-mcas.atlassian.net/browse/VAO-1358

## Description

Les toaster du portails usagers ne s'affichaient plus.

## Screenshot / liens loom 

## Check-list

 - [ ] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [ ] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
