### PR TITLE
fix: 1359 fusager block next with condition

### DIFF
--- a/packages/frontend-usagers/src/components/organisme/personne-physique.vue
+++ b/packages/frontend-usagers/src/components/organisme/personne-physique.vue
@@ -38,8 +38,10 @@
           <DsfrButton
             id="chercherSiret"
             :disabled="!siretMeta.valid"
+            label="Récupérer les informations de la personne physique"
+            aria-label="Récupérer les informations de la personne physique, cette action est action obligatoire pour la création de l'organisme"
             @click.prevent="searchOrganisme"
-            >Récupérer les informations de la personne physique
+          >
           </DsfrButton>
         </div>
       </div>
@@ -227,6 +229,7 @@
       <DsfrButton
         v-if="!props.isDownloading"
         id="next-step"
+        :disabled="!nomNaissance"
         @click.prevent="next"
         >Suivant
       </DsfrButton>
@@ -241,7 +244,12 @@
 <script setup lang="ts">
 import { useField, useForm } from "vee-validate";
 import * as yup from "yup";
-import { IsDownloading, ApiUnavailable, apiModel, useToaster } from "@vao/shared-ui";
+import {
+  IsDownloading,
+  ApiUnavailable,
+  apiModel,
+  useToaster,
+} from "@vao/shared-ui";
 import { SiretService } from "~/services/siretService";
 import {
   ERRORS_SIRET_MESSAGES,


### PR DESCRIPTION
## Ticket(s) lié(s)
1359

## Description
Erreur 500 sur le bouton suivant lors de la création de l'organisme Personne physique
## Screenshot / liens loom 
<img width="1101" height="672" alt="image" src="https://github.com/user-attachments/assets/e94448ea-8d31-4038-99ad-359c4b3cdc69" />

**Testing instructions**

    - [x] Créer un compte avec un siret de personne physique
    - [x]Valider les étapes de création de compte (mail + validation Dreets)
    - [x] Se connecter et cliquer sur "Organisme"
    - [X] Sélectionner "Personne Physique"
    - [X] Le bouton "Suivant" doit être grisé
    - [X] Cliquer sur "récupérer les informations de la personne physique"
    - [X] Les informations sont affichées et le bouton "Suivant" est dégrisé
    - [X] Le clique sur le bouton suivant ne génère plus d'erreur
