### PR TITLE
feat: 1263 fusager delete menue renew agrement

### DIFF
--- a/packages/frontend-usagers/src/composables/useMenuNavItem.ts
+++ b/packages/frontend-usagers/src/composables/useMenuNavItem.ts
@@ -47,10 +47,6 @@ export const useMenuNavItems = () => {
                   text: "Mon agrément",
                   to: "/mon-agrement",
                 },
-                {
-                  text: "Renouvellement d'agrément",
-                  to: "/agrement",
-                },
               ]
             : []),
         ],

--- a/packages/frontend-usagers/src/pages/mon-agrement/index.vue
+++ b/packages/frontend-usagers/src/pages/mon-agrement/index.vue
@@ -43,18 +43,25 @@
         <p class="fr-mt-4v">
           <b>Déclarer vos séjours</b> 2 mois minimum avant la date de départ
         </p>
-        <h2 class="fr-mb-0">
-          Formulaire du renouvellement d’agrément ({{
-            agrementAnneeRenouvellement
-          }})
-        </h2>
-        <AgrementReadOnly
-          class="fr-my-2w"
-          :init-organisme="organismeStore.organismeCourant ?? {}"
-          :init-agrement="agrementStore.agrementEnTraitement ?? {}"
-          :modifiable="false"
-          :cdn-url="`${config.public.backendUrl}/documents/`"
-        />
+        <span
+          v-if="
+            agrementStore.agrementEnTraitement?.statut !==
+            AGREMENT_STATUT.VALIDE
+          "
+        >
+          <h2 class="fr-mb-0">
+            Formulaire du renouvellement d’agrément ({{
+              agrementAnneeRenouvellement
+            }})
+          </h2>
+          <AgrementReadOnly
+            class="fr-my-2w"
+            :init-organisme="organismeStore.organismeCourant ?? {}"
+            :init-agrement="agrementStore.agrementEnTraitement ?? {}"
+            :modifiable="false"
+            :cdn-url="`${config.public.backendUrl}/documents/`"
+          />
+        </span>
       </DsfrTabContent>
 
       <DsfrTabContent

--- a/packages/frontend-usagers/src/stores/agrement.ts
+++ b/packages/frontend-usagers/src/stores/agrement.ts
@@ -115,7 +115,8 @@ export const useAgrementStore = defineStore("agrement", {
             ),
         );
         if (filtered.length === 0) {
-          this.agrementEnTraitement = null;
+          // Pas d'agrément en cours de renouvellement, on affiche l'agrément courant
+          this.agrementEnTraitement = this.agrementCourant;
           log.i("getEnRenouvellement - DONE no agrement in renouvellement");
           return;
         }


### PR DESCRIPTION
## Ticket(s) lié(s)
1263

## Description
Suppression du sous menu “Renouvellement agrément” ajouté par les dev pour faciliter l’accès (développé avant l'écran “Mon agrément”
Désormais l’accès ne se fera que par le menu “Mon agrément” ou par l'écran d’accueil sir l’agrément arrive à échéance
Dans le menu “Mon agrément”, si on n’est pas en période de renouvellement alors on affiche le statut de l’agrément courant. 
Afin qu’il n’y ait pas d’ambiguïté, l’agrément en cours de renouvellement est masqué sir l’agrément en cours est valide et pas de renouvellement à faire.

## Screenshot / liens loom 
<img width="417" height="199" alt="image" src="https://github.com/user-attachments/assets/7f6c6bf0-2109-4887-ac10-242dbb908da5" />

<img width="930" height="601" alt="image" src="https://github.com/user-attachments/assets/2956341d-0934-41a5-97a3-36dea7306cf8" />

<img width="930" height="601" alt="image" src="https://github.com/user-attachments/assets/c2d80498-b933-4948-b3e7-4a4dd0fe02e4" />

