### PR TITLE
chore: strip empty in query build request

### DIFF
--- a/packages/shared-bridge/src/utils/request.spec.ts
+++ b/packages/shared-bridge/src/utils/request.spec.ts
@@ -19,9 +19,14 @@ describe("buildRequestQueryString", () => {
   });
 
   it("should return a query string with an undefined query param", () => {
-    const query = { limit: undefined, page: 1 };
+    const query = { limit: undefined, page: 1, test: "" };
     // @ts-expect-error undefined is not a valid query param
     expect(buildRequestQueryString(query)).toEqual("?page=1");
+  });
+
+  it("should return a query string with an false query param", () => {
+    const query = { limit: false, page: 1 };
+    expect(buildRequestQueryString(query)).toEqual("?limit=false&page=1");
   });
 
   it("should return a query string with multiple query params", () => {

--- a/packages/shared-bridge/src/utils/request.ts
+++ b/packages/shared-bridge/src/utils/request.ts
@@ -12,6 +12,8 @@ export function buildRequestQueryString(
     // les tableaux étant mal interpretés par query-string, on parse les sous objets ou tableaux en JSON
     if (Array.isArray(value) || typeof value === "object") {
       return { ...acc, [key]: JSON.stringify(value) };
+    } else if (!value && value !== false && value !== 0) {
+      return acc;
     } else {
       return { ...acc, [key]: value };
     }


### PR DESCRIPTION
## Ticket(s) lié(s)

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description

empeche d'envoyer des valeurs null ou vide dans les query string quand on utilise le `buildRequest`

## Screenshot / liens loom 

## Check-list

 - [ ] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [ ] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
