### PR TITLE
feat: 1392 fusager migrate patch statut to post

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -74,7 +74,7 @@ fileignoreconfig:
 - filename: packages/backend/src/__tests__/usagers/accept-cgu.test.ts
   checksum: ab7a0f54777521ceb0cf4f2f253cc6f804e24ad7e27015eb9d66961366510a12
 - filename: packages/backend/src/__tests__/usagers/agrements.test.ts
-  checksum: 464bc103d92f763f3e4f8bef33db6902046255fbbda528f508a8073625dc5cd9
+  checksum: d0422a97e0bf3177d51d97c0253f50d254331976b359d55341760928e10cab16
 - filename: packages/backend/src/__tests__/usagers/authentification.test.ts
   checksum: 957632f5ccd2a7da70633b5291a95bb62110b47d3c78454f645e5a0501ce7e1d
 - filename: packages/backend/src/__tests__/usagers/documents.test.ts

--- a/packages/backend/src/__tests__/admin/agrements.test.ts
+++ b/packages/backend/src/__tests__/admin/agrements.test.ts
@@ -66,6 +66,7 @@ describe("GET /admin/agrements", () => {
     const agrementId1 = await createAgrement({
       agrement: agrementData,
       organismeId: organismeId1,
+      userId: authUser.id,
     });
     authUser2 = await createUsagersUser();
     const organismeId2 = await createOrganisme({ userId: authUser2.id });
@@ -75,6 +76,7 @@ describe("GET /admin/agrements", () => {
     const agrementId2 = await createAgrement({
       agrement: agrementData2,
       organismeId: organismeId2,
+      userId: authUser2.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const response = await request(app).get(`/admin/agrements`);
@@ -95,6 +97,7 @@ describe("GET /admin/agrements", () => {
     await createAgrement({
       agrement: agrementData,
       organismeId: organismeId1,
+      userId: authUser.id,
     });
     authUser2 = await createUsagersUser();
     const organismeId2 = await createOrganisme({ userId: authUser2.id });
@@ -104,6 +107,7 @@ describe("GET /admin/agrements", () => {
     await createAgrement({
       agrement: agrementData2,
       organismeId: organismeId2,
+      userId: authUser2.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const response = await request(app).get(
@@ -138,6 +142,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
 
@@ -176,6 +181,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const uuid = await createDocument({ userId: null });
@@ -219,6 +225,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     await createTerritoire({ territoireCode: "IDF" });
 
@@ -271,6 +278,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     await createTerritoire({ territoireCode: "IDF" });
 
@@ -340,6 +348,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     await createTerritoire({ territoireCode: "IDF" });
 
@@ -429,6 +438,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const response = await request(app)
@@ -452,6 +462,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     await createTerritoire({ territoireCode: "IDF" });
 
@@ -498,6 +509,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const response = await request(app)
@@ -525,6 +537,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
 
@@ -550,6 +563,7 @@ describe("PATCH /admin/agrements/{idAgrement}/statut", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
 
@@ -569,6 +583,7 @@ describe("GET /admin/agrements/:id", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
 
@@ -597,6 +612,7 @@ describe("GET /admin/agrements/history/:agrementId", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     await request(app)
@@ -622,6 +638,7 @@ describe("GET /admin/agrements/history/:agrementId", () => {
     const agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
     const response = await request(app).get(
@@ -650,6 +667,7 @@ describe("Messagerie d'agrément", () => {
     agrementId = await createAgrement({
       agrement: agrementData,
       organismeId,
+      userId: authUser.id,
     });
     authUserBo = await createAdminUser({ territoireCode: "IDF" });
   });

--- a/packages/backend/src/__tests__/fixtures/agrementsFixture.ts
+++ b/packages/backend/src/__tests__/fixtures/agrementsFixture.ts
@@ -77,6 +77,38 @@ export async function buildAgrementFixture({
         category: FILE_CATEGORY.IMMATRICUL,
         fileUuid: randomUUID(),
       } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.PROCVERBAL,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.ASSURRESP,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.ASSURRAPAT,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.BILANQUALITPERCEPTION,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.BILANQUALITPERSPECTIVE,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.BILANQUALITELEMARQ,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.PROJETSSEJOURSCOMPETENCESEXPERIENCE,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
+      {
+        category: FILE_CATEGORY.PROJETSSEJOURSMESURES,
+        fileUuid: randomUUID(),
+      } as AgrementFilesDto,
     ],
     agrementSejours: agrementSejours ?? [
       {
@@ -120,7 +152,7 @@ export async function buildAgrementFixture({
     regionObtention: regionObtention ?? "IDF",
     sejourCommentaire: "Commentaire de test",
     sejourNbEnvisage: 2,
-    sejourTypeHandicap: [],
+    sejourTypeHandicap: [TYPE_HANDICAP.MOTEUR],
     statut,
     suiviMedAccordSejour: "Oui",
     suiviMedDistribution: "Oui",

--- a/packages/backend/src/__tests__/helpers/agrementsHelper.ts
+++ b/packages/backend/src/__tests__/helpers/agrementsHelper.ts
@@ -5,9 +5,11 @@ import { AgrementService } from "../../usagers/agrements/agrements.service";
 export const createAgrement = async ({
   organismeId = null,
   agrement = {},
+  userId = null,
 }: {
   agrement?: Partial<AgrementDto> | null;
   organismeId?: number | null;
+  userId?: string | number | null;
 } = {}): Promise<number> => {
   const fixture: AgrementDto = {
     dateObtentionCertificat: new Date("2025-01-01"),
@@ -16,7 +18,7 @@ export const createAgrement = async ({
     regionObtention: "IDF",
     ...agrement,
   } as unknown as AgrementDto;
-  const agrementId = await AgrementService.save(fixture);
+  const agrementId = await AgrementService.save(fixture, userId as string);
   return agrementId;
 };
 

--- a/packages/backend/src/__tests__/usagers/agrements.test.ts
+++ b/packages/backend/src/__tests__/usagers/agrements.test.ts
@@ -268,6 +268,493 @@ describe("POST /agrements", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("devrait changer le statut d'un agrément avec succès", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+
+    const agrementId = await createAgrement({
+      agrement: { ...agrementData },
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    const response = await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(agrementId);
+
+    // Vérifier que l'événement a bien été historisé
+    const history = await AgrementService.getHistory(agrementId);
+    const aModifierEvent = history.find(
+      (event) =>
+        event.type === AGREMENT_HISTORY_TYPE.MODIFICATION ||
+        event.type_precision === AGREMENT_STATUT.TRANSMIS,
+    );
+
+    expect(aModifierEvent).toBeDefined();
+    expect(aModifierEvent?.usager_user).toBeDefined();
+    const { agrement } = await getAgrement(agrementId);
+    expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
+    expect(agrement?.dateDepot).not.toBeNull();
+    expect(agrement?.dateDepot ? formatFR(agrement?.dateDepot) : null).toBe(
+      formatFR(new Date()),
+    );
+  });
+
+  it("renseigne organismeName et siret pour une personne morale lors de l'envoi du mail à la région", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({
+      organisme: {
+        personneMorale: {
+          raisonSociale: "ACME Corp",
+          siret: "12345678900000",
+        },
+        typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
+      },
+      userId: adminUser.id,
+    });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    // Mock explicite pour couvrir la branche PERSONNE_MORALE
+    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce({
+      id: organismeId,
+      personneMorale: {
+        raisonSociale: "ACME Corp",
+        siret: "12345678900000",
+      },
+      typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+
+    // Vérifie que le mail envoyé à la région contient la raison sociale et le siret
+    const calls = (mailService.send as jest.Mock).mock.calls;
+
+    const mailToRegion = calls.find((call) => {
+      const to = call[0].to || call[0].email;
+      return to && to.endsWith("@territoire.com");
+    });
+    if (!mailToRegion) {
+      // Debug: afficher tous les appels pour comprendre la structure
+      // eslint-disable-next-line no-console
+      console.error(
+        "mailService.send calls:",
+        calls.map((c) => c[0]),
+      );
+    }
+    expect(mailToRegion).toBeDefined();
+    expect(mailToRegion[0].html).toContain("ACME Corp");
+    expect(mailToRegion[0].html).toContain("12345678900000");
+  });
+  it("renseigne organismeName pour une personne physique lors de l'envoi du mail à la région", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({
+      organisme: {
+        personnePhysique: {
+          nom: "Dupont",
+          prenom: "Jean",
+        },
+        typeOrganisme: ORGANISME_TYPE.PERSONNE_PHYSIQUE,
+      },
+      userId: adminUser.id,
+    });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    // Mock explicite pour couvrir la branche PERSONNE_PHYSIQUE
+    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce({
+      id: organismeId,
+      personnePhysique: {
+        nom: "Dupont",
+        nomNaissance: "Dupont",
+        nomUsage: "Jean Dupont",
+        prenom: "Jean",
+      },
+      typeOrganisme: ORGANISME_TYPE.PERSONNE_PHYSIQUE,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+
+    // Vérifie que le mail envoyé à la région contient le nom et prénom de la personne physique
+    const calls = (mailService.send as jest.Mock).mock.calls;
+    const mailToRegion = calls.find((call) => {
+      const to = call[0].to || call[0].email;
+      return to && to.endsWith("@territoire.com");
+    });
+    if (!mailToRegion) {
+      // Debug: afficher tous les appels pour comprendre la structure
+      // eslint-disable-next-line no-console
+      console.error(
+        "mailService.send calls:",
+        calls.map((c) => c[0]),
+      );
+    }
+    expect(mailToRegion).toBeDefined();
+    expect(mailToRegion[0].html).toContain("Jean Dupont");
+    // Pas de siret pour une personne physique
+    expect(mailToRegion[0].html).not.toMatch(/\d{14}/); // ou adapte selon le rendu attendu
+  });
+
+  it("envoie un mail à la région et à l’usager lors du passage à TRANSMIS", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(2);
+    const calls = (mailService.send as jest.Mock).mock.calls;
+    expect(calls[0][0]).toHaveProperty("to");
+    expect(calls[1][0]).toHaveProperty("to");
+    expect(calls.some((call) => call[0].to && call[0].to.includes("@"))).toBe(
+      true,
+    );
+  });
+
+  it("n’envoie pas de mail à la région si la région est inconnue", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "AAA",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(1);
+    const call = (mailService.send as jest.Mock).mock.calls[0][0];
+    expect(call).toHaveProperty("to");
+    expect(call.html).toMatch(/DREETS compétente/);
+  });
+  it("log une erreur si l'envoi du mail à la région échoue", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (mailService.send as jest.Mock)
+      .mockImplementationOnce(() => {
+        throw new Error("Erreur d'envoi mail région");
+      })
+      .mockImplementationOnce(() => {}); // usager
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("log une erreur si l'envoi du mail à l'usager échoue", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (mailService.send as jest.Mock)
+      .mockImplementationOnce(() => {}) // région
+      .mockImplementationOnce(() => {
+        throw new Error("Erreur d'envoi mail usager");
+      });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("n’envoie pas de mail à la région si l’email de la région est manquant", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    await createTerritoire({
+      territoire: { email: null },
+      territoireCode: "IDF",
+    });
+
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(1);
+    const call = (mailService.send as jest.Mock).mock.calls[0][0];
+    expect(call).toHaveProperty("to");
+    expect(call.html).toMatch(/DREETS/);
+  });
+
+  it("n’envoie pas de mail si l’organisme est introuvable", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "IDF",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce(null);
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(1);
+    const call = (mailService.send as jest.Mock).mock.calls[0][0];
+    expect(call).toHaveProperty("to");
+    expect(call.html).toMatch(/DREETS/);
+  });
+
+  it("envoie un mail à l’usager avec fallback si la région est inconnue", async () => {
+    const adminUser = await createUsagersUser();
+    const organismeId = await createOrganisme({ userId: adminUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      regionObtention: "AAA",
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: adminUser.id };
+      next();
+    });
+    await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(1);
+    const call = (mailService.send as jest.Mock).mock.calls[0][0];
+    expect(call).toHaveProperty("to");
+    expect(call.html).toMatch(/DREETS compétente/);
+  });
+  it("devrait changer le statut en agrement TRANSMIS après modification", async () => {
+    const usagerUser = await createUsagersUser();
+    // Ici on répond aux conditions de mise à jour backOffice
+    const adminUser = await createAdminUser();
+    await createTerritoire({ territoireCode: "IDF" });
+    const organismeId = await createOrganisme({ userId: usagerUser.id });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: usagerUser.id };
+      next();
+    });
+    const response = await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(mailService.send).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(agrementId);
+
+    // Mise à jour côté Admin pour demande de complétion du dossier
+    await AgrementServiceAdmin.updateStatut({
+      agrementId,
+      boUserId: adminUser.id,
+      commentaire:
+        "Dossier à compléter car il manque des éléments pour pouvoir le traiter",
+      statut: AGREMENT_STATUT.A_MODIFIER,
+      territoireCode: agrementData.regionObtention!,
+    });
+    expect(mailService.send).toHaveBeenCalledTimes(3);
+
+    // Transmission de l'agrément au Service après complétude
+    const responseCorrection = await request(app)
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+      });
+    expect(responseCorrection.status).toBe(200);
+    expect(responseCorrection.body.id).toBe(agrementId);
+    expect(mailService.send).toHaveBeenCalledTimes(5);
+    // Vérifier que l'événement a bien été historisé
+    const history = await AgrementService.getHistory(agrementId);
+    const aModifierEvent = history.find(
+      (event) =>
+        event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
+        event.type_precision === AGREMENT_STATUT.TRANSMIS,
+    );
+
+    expect(aModifierEvent).toBeDefined();
+    expect(aModifierEvent?.usager_user).toBeDefined();
+    const { agrement } = await getAgrement(agrementId);
+    expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
+  });
 });
 
 describe("PATCH /agrements/:agrementId/statut", () => {
@@ -328,9 +815,13 @@ describe("PATCH /agrements/:agrementId/statut", () => {
       req.decoded = { id: adminUser.id };
       next();
     });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
+
+    const newAgrementData = {
+      ...agrementData,
+      id: agrementId,
+      statut: AGREMENT_STATUT.TRANSMIS,
+    };
+    await request(app).post(`/agrements/`).send(newAgrementData);
 
     // Vérifie que le mail envoyé à la région contient le nom et prénom de la personne physique
     const calls = (mailService.send as jest.Mock).mock.calls;
@@ -339,176 +830,6 @@ describe("PATCH /agrements/:agrementId/statut", () => {
       return to && to.endsWith("@territoire.com");
     });
     expect(mailToRegion).toBeUndefined();
-  });
-  it("renseigne organismeName pour une personne physique lors de l'envoi du mail à la région", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({
-      organisme: {
-        personnePhysique: {
-          nom: "Dupont",
-          prenom: "Jean",
-        },
-        typeOrganisme: ORGANISME_TYPE.PERSONNE_PHYSIQUE,
-      },
-      userId: adminUser.id,
-    });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    await createTerritoire({
-      territoire: { service_mail: "region-idf@example.com" },
-      territoireCode: "IDF",
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    // Mock explicite pour couvrir la branche PERSONNE_PHYSIQUE
-    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce({
-      id: organismeId,
-      personnePhysique: {
-        nom: "Dupont",
-        nomNaissance: "Dupont",
-        nomUsage: "Jean Dupont",
-        prenom: "Jean",
-      },
-      typeOrganisme: ORGANISME_TYPE.PERSONNE_PHYSIQUE,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-
-    // Vérifie que le mail envoyé à la région contient le nom et prénom de la personne physique
-    const calls = (mailService.send as jest.Mock).mock.calls;
-    const mailToRegion = calls.find((call) => {
-      const to = call[0].to || call[0].email;
-      return to && to.endsWith("@territoire.com");
-    });
-    if (!mailToRegion) {
-      // Debug: afficher tous les appels pour comprendre la structure
-      // eslint-disable-next-line no-console
-      console.error(
-        "mailService.send calls:",
-        calls.map((c) => c[0]),
-      );
-    }
-    expect(mailToRegion).toBeDefined();
-    expect(mailToRegion[0].html).toContain("Jean Dupont");
-    // Pas de siret pour une personne physique
-    expect(mailToRegion[0].html).not.toMatch(/\d{14}/); // ou adapte selon le rendu attendu
-  });
-  it("renseigne organismeName et siret pour une personne morale lors de l'envoi du mail à la région", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({
-      organisme: {
-        personneMorale: {
-          raisonSociale: "ACME Corp",
-          siret: "12345678900000",
-        },
-        typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
-      },
-      userId: adminUser.id,
-    });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    await createTerritoire({
-      territoire: { service_mail: "region-idf@example.com" },
-      territoireCode: "IDF",
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    // Mock explicite pour couvrir la branche PERSONNE_MORALE
-    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce({
-      id: organismeId,
-      personneMorale: {
-        raisonSociale: "ACME Corp",
-        siret: "12345678900000",
-      },
-      typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-
-    // Vérifie que le mail envoyé à la région contient la raison sociale et le siret
-    const calls = (mailService.send as jest.Mock).mock.calls;
-
-    const mailToRegion = calls.find((call) => {
-      const to = call[0].to || call[0].email;
-      return to && to.endsWith("@territoire.com");
-    });
-    if (!mailToRegion) {
-      // Debug: afficher tous les appels pour comprendre la structure
-      // eslint-disable-next-line no-console
-      console.error(
-        "mailService.send calls:",
-        calls.map((c) => c[0]),
-      );
-    }
-    expect(mailToRegion).toBeDefined();
-    expect(mailToRegion[0].html).toContain("ACME Corp");
-    expect(mailToRegion[0].html).toContain("12345678900000");
-  });
-  it("devrait changer le statut d'un agrément avec succès", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-
-    await createTerritoire({
-      territoire: { service_mail: "region-idf@example.com" },
-      territoireCode: "IDF",
-    });
-
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    const response = await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-
-    // Vérifier que l'événement a bien été historisé
-    const history = await AgrementService.getHistory(agrementId);
-    const aModifierEvent = history.find(
-      (event) =>
-        event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
-        event.type_precision === AGREMENT_STATUT.TRANSMIS,
-    );
-
-    expect(aModifierEvent).toBeDefined();
-    expect(aModifierEvent?.usager_user).toBeDefined();
-    const { agrement } = await getAgrement(agrementId);
-    expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
-    expect(agrement?.dateDepot).not.toBeNull();
-    expect(agrement?.dateDepot ? formatFR(agrement?.dateDepot) : null).toBe(
-      formatFR(new Date()),
-    );
   });
 
   it("workflow changement statut de l'agrement", async () => {
@@ -540,203 +861,7 @@ describe("PATCH /agrements/:agrementId/statut", () => {
     const { agrement } = await getAgrement(agrementId);
     expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
 
-    expect(mailService.send).toHaveBeenCalledTimes(2);
-  });
-
-  it("envoie un mail à la région et à l’usager lors du passage à TRANSMIS", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(2);
-    const calls = (mailService.send as jest.Mock).mock.calls;
-    expect(calls[0][0]).toHaveProperty("to");
-    expect(calls[1][0]).toHaveProperty("to");
-    expect(calls.some((call) => call[0].to && call[0].to.includes("@"))).toBe(
-      true,
-    );
-  });
-
-  it("n’envoie pas de mail à la région si la région est inconnue", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "AAA",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(1);
-    const call = (mailService.send as jest.Mock).mock.calls[0][0];
-    expect(call).toHaveProperty("to");
-    expect(call.html).toMatch(/DREETS compétente/);
-  });
-
-  it("log une erreur si l'envoi du mail à la région échoue", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    await createTerritoire({
-      territoire: { service_mail: "region-idf@example.com" },
-      territoireCode: "IDF",
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (mailService.send as jest.Mock)
-      .mockImplementationOnce(() => {
-        throw new Error("Erreur d'envoi mail région");
-      })
-      .mockImplementationOnce(() => {}); // usager
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(2);
-  });
-
-  it("log une erreur si l'envoi du mail à l'usager échoue", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    await createTerritoire({
-      territoire: { service_mail: "region-idf@example.com" },
-      territoireCode: "IDF",
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (mailService.send as jest.Mock)
-      .mockImplementationOnce(() => {}) // région
-      .mockImplementationOnce(() => {
-        throw new Error("Erreur d'envoi mail usager");
-      });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(2);
-  });
-
-  it("n’envoie pas de mail à la région si l’email de la région est manquant", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    await createTerritoire({
-      territoire: { email: null },
-      territoireCode: "IDF",
-    });
-
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(1);
-    const call = (mailService.send as jest.Mock).mock.calls[0][0];
-    expect(call).toHaveProperty("to");
-    expect(call.html).toMatch(/DREETS/);
-  });
-
-  it("n’envoie pas de mail si l’organisme est introuvable", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (OrganismeService.getOne as jest.Mock).mockResolvedValueOnce(null);
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(1);
-    const call = (mailService.send as jest.Mock).mock.calls[0][0];
-    expect(call).toHaveProperty("to");
-    expect(call.html).toMatch(/DREETS/);
-  });
-
-  it("envoie un mail à l’usager avec fallback si la région est inconnue", async () => {
-    const adminUser = await createUsagersUser();
-    const organismeId = await createOrganisme({ userId: adminUser.id });
-    const agrementData = await buildAgrementFixture({
-      organismeId,
-      regionObtention: "AAA",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    const agrementId = await createAgrement({
-      agrement: agrementData,
-      organismeId,
-    });
-    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-      req.decoded = { id: adminUser.id };
-      next();
-    });
-    await request(app)
-      .patch(`/agrements/${agrementId}/statut`)
-      .send({ statut: AGREMENT_STATUT.TRANSMIS });
-    expect(mailService.send).toHaveBeenCalledTimes(1);
-    const call = (mailService.send as jest.Mock).mock.calls[0][0];
-    expect(call).toHaveProperty("to");
-    expect(call.html).toMatch(/DREETS compétente/);
+    expect(mailService.send).toHaveBeenCalledTimes(0);
   });
 
   it("devrait changer le statut d'un agrément avec succès pour le retour de complétude", async () => {
@@ -794,163 +919,105 @@ describe("PATCH /agrements/:agrementId/statut", () => {
     expect(responseCorrection.status).toBe(200);
     expect(responseCorrection.body.success).toBe(true);
   });
-});
+  it("devrait changer le statut en agrement VALIDE", async () => {
+    const usagerUser = await createUsagersUser();
+    // Ici on répond aux conditions de mise à jour backOffice
+    const adminUser = await createAdminUser();
+    await createTerritoire({ territoireCode: "IDF" });
+    const organismeId = await createOrganisme({ userId: usagerUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: usagerUser.id };
+      next();
+    });
+    const response = await request(app)
+      .patch(`/agrements/${agrementId}/statut`)
+      .send({ statut: AGREMENT_STATUT.TRANSMIS });
+    await AgrementServiceAdmin.updateStatut({
+      agrementId,
+      boUserId: adminUser.id,
+      statut: AGREMENT_STATUT.COMPLETUDE_CONFIRME,
+      territoireCode: agrementData.regionObtention!,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
 
-it("devrait changer le statut en agrement VALIDE", async () => {
-  const usagerUser = await createUsagersUser();
-  // Ici on répond aux conditions de mise à jour backOffice
-  const adminUser = await createAdminUser();
-  await createTerritoire({ territoireCode: "IDF" });
-  const organismeId = await createOrganisme({ userId: usagerUser.id });
-  const agrementData = await buildAgrementFixture({
-    organismeId,
-    statut: AGREMENT_STATUT.BROUILLON,
-  });
-  const agrementId = await createAgrement({
-    agrement: agrementData,
-    organismeId,
-  });
-  (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-    req.decoded = { id: usagerUser.id };
-    next();
-  });
-  const response = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.TRANSMIS });
-  await AgrementServiceAdmin.updateStatut({
-    agrementId,
-    boUserId: adminUser.id,
-    statut: AGREMENT_STATUT.COMPLETUDE_CONFIRME,
-    territoireCode: agrementData.regionObtention!,
-  });
-  expect(response.status).toBe(200);
-  expect(response.body.success).toBe(true);
+    const responseCorrection = await request(app)
+      .patch(`/agrements/${agrementId}/statut`)
+      .send({ statut: AGREMENT_STATUT.VALIDE });
+    expect(responseCorrection.status).toBe(200);
+    expect(responseCorrection.body.success).toBe(true);
 
-  const responseCorrection = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.VALIDE });
-  expect(responseCorrection.status).toBe(200);
-  expect(responseCorrection.body.success).toBe(true);
+    // Vérifier que l'événement a bien été historisé
+    const history = await AgrementService.getHistory(agrementId);
+    const aModifierEvent = history.find(
+      (event) =>
+        event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
+        event.type_precision === AGREMENT_STATUT.VALIDE,
+    );
 
-  // Vérifier que l'événement a bien été historisé
-  const history = await AgrementService.getHistory(agrementId);
-  const aModifierEvent = history.find(
-    (event) =>
-      event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
-      event.type_precision === AGREMENT_STATUT.VALIDE,
-  );
-
-  expect(aModifierEvent).toBeDefined();
-  expect(aModifierEvent?.usager_user).toBeDefined();
-  const { agrement } = await getAgrement(agrementId);
-  expect(agrement?.statut).toBe(AGREMENT_STATUT.VALIDE);
-});
-
-it("devrait changer le statut en agrement TRANSMIS après modification", async () => {
-  const usagerUser = await createUsagersUser();
-  // Ici on répond aux conditions de mise à jour backOffice
-  const adminUser = await createAdminUser();
-  await createTerritoire({ territoireCode: "IDF" });
-  const organismeId = await createOrganisme({ userId: usagerUser.id });
-  const agrementData = await buildAgrementFixture({
-    organismeId,
-    statut: AGREMENT_STATUT.BROUILLON,
+    expect(aModifierEvent).toBeDefined();
+    expect(aModifierEvent?.usager_user).toBeDefined();
+    const { agrement } = await getAgrement(agrementId);
+    expect(agrement?.statut).toBe(AGREMENT_STATUT.VALIDE);
   });
-  const agrementId = await createAgrement({
-    agrement: agrementData,
-    organismeId,
-  });
-  (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-    req.decoded = { id: usagerUser.id };
-    next();
-  });
-  const response = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.TRANSMIS });
-  expect(mailService.send).toHaveBeenCalledTimes(2);
-  expect(response.status).toBe(200);
-  expect(response.body.success).toBe(true);
 
-  // Mise à jour côté Admin pour demande de complétion du dossier
-  await AgrementServiceAdmin.updateStatut({
-    agrementId,
-    boUserId: adminUser.id,
-    commentaire:
-      "Dossier à compléter car il manque des éléments pour pouvoir le traiter",
-    statut: AGREMENT_STATUT.A_MODIFIER,
-    territoireCode: agrementData.regionObtention!,
+  it("devrait changer le statut en agrement REFUSE", async () => {
+    const usagerUser = await createUsagersUser();
+    // Ici on répond aux conditions de mise à jour backOffice
+    const adminUser = await createAdminUser();
+    await createTerritoire({ territoireCode: "IDF" });
+    const organismeId = await createOrganisme({ userId: usagerUser.id });
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
+      req.decoded = { id: usagerUser.id };
+      next();
+    });
+    const response = await request(app)
+      .patch(`/agrements/${agrementId}/statut`)
+      .send({ statut: AGREMENT_STATUT.TRANSMIS });
+    await AgrementServiceAdmin.updateStatut({
+      agrementId,
+      boUserId: adminUser.id,
+      statut: AGREMENT_STATUT.COMPLETUDE_CONFIRME,
+      territoireCode: agrementData.regionObtention!,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+
+    const responseCorrection = await request(app)
+      .patch(`/agrements/${agrementId}/statut`)
+      .send({ statut: AGREMENT_STATUT.REFUSE });
+    expect(responseCorrection.status).toBe(200);
+    expect(responseCorrection.body.success).toBe(true);
+
+    // Vérifier que l'événement a bien été historisé
+    const history = await AgrementService.getHistory(agrementId);
+    const aModifierEvent = history.find(
+      (event) =>
+        event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
+        event.type_precision === AGREMENT_STATUT.VALIDE,
+    );
+
+    expect(aModifierEvent).toBeDefined();
+    expect(aModifierEvent?.usager_user).toBeDefined();
+    const { agrement } = await getAgrement(agrementId);
+    expect(agrement?.statut).toBe(AGREMENT_STATUT.REFUSE);
   });
-  expect(mailService.send).toHaveBeenCalledTimes(3);
-
-  // Transmission de l'agrément au Service après complétude
-  const responseCorrection = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.TRANSMIS });
-  expect(responseCorrection.status).toBe(200);
-  expect(responseCorrection.body.success).toBe(true);
-  expect(mailService.send).toHaveBeenCalledTimes(4);
-  // Vérifier que l'événement a bien été historisé
-  const history = await AgrementService.getHistory(agrementId);
-  const aModifierEvent = history.find(
-    (event) =>
-      event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
-      event.type_precision === AGREMENT_STATUT.TRANSMIS,
-  );
-
-  expect(aModifierEvent).toBeDefined();
-  expect(aModifierEvent?.usager_user).toBeDefined();
-  const { agrement } = await getAgrement(agrementId);
-  expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
-});
-
-it("devrait changer le statut en agrement REFUSE", async () => {
-  const usagerUser = await createUsagersUser();
-  // Ici on répond aux conditions de mise à jour backOffice
-  const adminUser = await createAdminUser();
-  await createTerritoire({ territoireCode: "IDF" });
-  const organismeId = await createOrganisme({ userId: usagerUser.id });
-  const agrementData = await buildAgrementFixture({
-    organismeId,
-    statut: AGREMENT_STATUT.BROUILLON,
-  });
-  const agrementId = await createAgrement({
-    agrement: agrementData,
-    organismeId,
-  });
-  (checkJwt as jest.Mock).mockImplementation((req, _res, next) => {
-    req.decoded = { id: usagerUser.id };
-    next();
-  });
-  const response = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.TRANSMIS });
-  await AgrementServiceAdmin.updateStatut({
-    agrementId,
-    boUserId: adminUser.id,
-    statut: AGREMENT_STATUT.COMPLETUDE_CONFIRME,
-    territoireCode: agrementData.regionObtention!,
-  });
-  expect(response.status).toBe(200);
-  expect(response.body.success).toBe(true);
-
-  const responseCorrection = await request(app)
-    .patch(`/agrements/${agrementId}/statut`)
-    .send({ statut: AGREMENT_STATUT.REFUSE });
-  expect(responseCorrection.status).toBe(200);
-  expect(responseCorrection.body.success).toBe(true);
-
-  // Vérifier que l'événement a bien été historisé
-  const history = await AgrementService.getHistory(agrementId);
-  const aModifierEvent = history.find(
-    (event) =>
-      event.type === AGREMENT_HISTORY_TYPE.STATUT_CHANGE ||
-      event.type_precision === AGREMENT_STATUT.VALIDE,
-  );
-
-  expect(aModifierEvent).toBeDefined();
-  expect(aModifierEvent?.usager_user).toBeDefined();
-  const { agrement } = await getAgrement(agrementId);
-  expect(agrement?.statut).toBe(AGREMENT_STATUT.REFUSE);
 });
 
 describe("upload fichiers", () => {

--- a/packages/backend/src/usagers/agrements/agrements.controller.ts
+++ b/packages/backend/src/usagers/agrements/agrements.controller.ts
@@ -155,13 +155,15 @@ export const AgrementController = {
     const agrement = req.validatedBody!;
     const { id: usagerUserId } = req.decoded!;
     try {
-      const id = await AgrementService.save(agrement);
+      const id = await AgrementService.save(agrement, usagerUserId);
       log.i("Agrement saved", { id });
 
       await AgrementService.trackEvent({
         agrementId: id,
         source: "usager",
-        type: AGREMENT_HISTORY_TYPE.CREATION,
+        type: agrement?.id
+          ? AGREMENT_HISTORY_TYPE.MODIFICATION
+          : AGREMENT_HISTORY_TYPE.CREATION,
         usagerUserId: Number(usagerUserId),
       });
 

--- a/packages/backend/src/usagers/agrements/agrements.repository.ts
+++ b/packages/backend/src/usagers/agrements/agrements.repository.ts
@@ -712,21 +712,18 @@ export const AgrementsRepository = {
   async updateStatut({
     agrementId,
     statut,
-    dateDepot,
     tx,
   }: {
     agrementId: number;
     statut: AGREMENT_STATUT;
-    dateDepot: Date | null;
     tx: PoolClient;
   }): Promise<number | null> {
     const result = await tx.query(
       `UPDATE front.agrements
       SET statut = $1,
-        updated_at = NOW(),
-        date_depot = $3
-      WHERE id = $2`,
-      [statut, agrementId, dateDepot],
+        updated_at = NOW()
+        WHERE id = $2`,
+      [statut, agrementId],
     );
     return result.rowCount;
   },

--- a/packages/backend/src/usagers/agrements/agrements.service.spec.ts
+++ b/packages/backend/src/usagers/agrements/agrements.service.spec.ts
@@ -117,6 +117,9 @@ describe("AgrementService when agrement does not exist (coverage)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (AgrementsRepository.getById as jest.Mock).mockResolvedValue(null);
+    (withTransaction as jest.Mock).mockImplementation(async (callback) =>
+      callback({} as never),
+    );
   });
 
   it("getMessages should throw 404 when agrement does not exist", async () => {
@@ -148,16 +151,18 @@ describe("AgrementService when agrement does not exist (coverage)", () => {
     });
   });
 
-  it("updateStatut should throw 404 when agrement does not exist", async () => {
+  it("updateStatut should throw 500 when agrement does not exist", async () => {
+    (AgrementsRepository.updateStatut as jest.Mock).mockResolvedValue(0);
+
     await expect(
       AgrementService.updateStatut({
         agrementId: 999999,
-        statut: "TRANSMIS" as never,
+        statut: AGREMENT_STATUT.TRANSMIS,
         usagerUserId: "1",
       }),
     ).rejects.toMatchObject({
-      message: "Agrement non trouvé",
-      statusCode: 404,
+      message: "Échec de la mise à jour du statut",
+      statusCode: 500,
     });
   });
 });
@@ -244,32 +249,6 @@ describe("AgrementService additional branch coverage", () => {
 
     expect(result).toBe(true);
     expect(mailService.send).not.toHaveBeenCalled();
-  });
-
-  it("updateStatut should handle region without fiche id", async () => {
-    (AgrementsRepository.getById as jest.Mock).mockResolvedValue({
-      dateDepot: null,
-      id: 1,
-      organismeId: 1,
-      regionObtention: "IDF",
-      statut: AGREMENT_STATUT.BROUILLON,
-    });
-    (AgrementsRepository.updateStatut as jest.Mock).mockResolvedValue(true);
-    (AgrementsRepository.getUserMail as jest.Mock).mockResolvedValue(
-      "usager@example.com",
-    );
-    (TerritoireService.readFicheIdByTerCode as jest.Mock).mockResolvedValue(
-      null,
-    );
-
-    const result = await AgrementService.updateStatut({
-      agrementId: 1,
-      statut: AGREMENT_STATUT.TRANSMIS,
-      usagerUserId: "1",
-    });
-
-    expect(result).toBe(true);
-    expect(mailService.send).toHaveBeenCalledTimes(1);
   });
 
   it("updateSvaTimer should throw 500 when timerId is missing", async () => {

--- a/packages/backend/src/usagers/agrements/agrements.service.ts
+++ b/packages/backend/src/usagers/agrements/agrements.service.ts
@@ -121,14 +121,131 @@ export const AgrementService = {
       });
     }
   },
-  async save(agrement: AgrementDto): Promise<number> {
+  async save(agrement: AgrementDto, userId: string): Promise<number> {
     agrement.dateFinValidite = addYears(agrement?.dateObtention, 5);
     let agrementId = null;
-
     if (agrement && agrement?.id) {
+      const agrementAvant = await AgrementsRepository.getById({
+        agrementId: agrement?.id,
+        withDetails: false,
+      });
+      const premiereTransmission =
+        agrementAvant?.statut === AGREMENT_STATUT.BROUILLON &&
+        agrement.statut === AGREMENT_STATUT.TRANSMIS;
+      // Ajout de la date de dépôt lorqu'il s'agit de la première transmission
+      agrement.dateDepot = premiereTransmission
+        ? new Date()
+        : agrement?.dateDepot;
+
       agrementId = await AgrementsRepository.update({
         agrement,
       });
+      if (agrement.statut === AGREMENT_STATUT.TRANSMIS) {
+        try {
+          await AgrementService.trackEvent({
+            agrementId,
+            source: "usager",
+            type: AGREMENT_HISTORY_TYPE.TRANSMISSION,
+            typePrecision: AGREMENT_STATUT.TRANSMIS,
+            usagerUserId: Number(userId),
+          });
+        } catch (e) {
+          log.w(
+            "Impossible de tracer l'historique. AgrementId=" + agrementId,
+            e,
+          );
+        }
+
+        const email = await AgrementsRepository.getUserMail(agrementId);
+        const date = new Date().toLocaleDateString("fr-FR", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        });
+
+        let organismeName = "";
+        let siret = "";
+        let nomObtentionRegion = null;
+        let emailRegion: string | null = null;
+
+        try {
+          const organisme: OrganismeDto | null = await Organisme.getOne({
+            "o.id": agrement.organismeId,
+          });
+
+          if (!organisme) {
+            log.w(`Organisme introuvable pour agrementId=${agrementId}`);
+          } else if (
+            organisme.typeOrganisme === ORGANISME_TYPE.PERSONNE_MORALE &&
+            organisme.personneMorale
+          ) {
+            organismeName = organisme.personneMorale.raisonSociale || "";
+            siret = organisme.personneMorale.siret || "";
+          } else if (
+            organisme.typeOrganisme === ORGANISME_TYPE.PERSONNE_PHYSIQUE &&
+            organisme.personnePhysique
+          ) {
+            organismeName =
+              organisme.personnePhysique.nomUsage?.trim() ||
+              organisme.personnePhysique.nomNaissance ||
+              "";
+            siret = organisme.personnePhysique.siret || "";
+          }
+
+          const codeObtentionRegion = agrement.regionObtention || null;
+          if (codeObtentionRegion) {
+            const region = await Region.fetchOne(codeObtentionRegion);
+            nomObtentionRegion = region.text;
+            emailRegion = await getEmailRegion(codeObtentionRegion);
+          }
+        } catch (e) {
+          log.w(
+            "Impossible d'envoyer l'email à la région : informations manquantes ou erreur lors de la récupération. AgrementId=" +
+              agrementId,
+            e,
+          );
+        }
+
+        if (emailRegion) {
+          try {
+            const mailToSend = premiereTransmission
+              ? // Première Transmission
+                AgrementMailAdmin.sendStatutTransmisRegionMail({
+                  agrementId,
+                  date,
+                  email: emailRegion,
+                  organismeName,
+                  siret,
+                })
+              : // Transmission après demande de modification
+                AgrementMailAdmin.sendStatutModificationTransmisRegionMail({
+                  agrementId,
+                  email: emailRegion,
+                  organismeName,
+                });
+            await mailService.send(mailToSend);
+          } catch (e) {
+            log.w("Erreur lors de l'envoi de l'email à la région", e);
+          }
+        }
+
+        if (!email) {
+          log.w("Aucun email trouvé pour l'agrément", agrementId);
+          return agrementId;
+        }
+
+        try {
+          await mailService.send(
+            AgrementMailUsagers.sendStatutTransmisMail({
+              date,
+              email,
+              regionDreets: nomObtentionRegion,
+            }),
+          );
+        } catch (e) {
+          log.w("Erreur lors de l'envoi de l'email de transmission", e);
+        }
+      }
       log.d("updated meta values - DONE", { agrementId });
     } else {
       agrementId = await AgrementsRepository.create({
@@ -136,6 +253,7 @@ export const AgrementService = {
       });
       log.d("Add meta values - DONE", { agrementId });
     }
+
     return agrementId;
   },
   async trackEvent(event: {
@@ -157,23 +275,9 @@ export const AgrementService = {
     statut: AGREMENT_STATUT;
     usagerUserId: string;
   }): Promise<boolean> {
-    const agrement = await AgrementsRepository.getById({
-      agrementId,
-      withDetails: false,
-    });
-    if (!agrement) {
-      log.w("Agrement non trouvé", agrementId);
-      throw new AppError("Agrement non trouvé", { statusCode: 404 });
-    }
-    const dateDepot = agrement?.dateDepot
-      ? agrement?.dateDepot
-      : statut === AGREMENT_STATUT.TRANSMIS
-        ? new Date()
-        : null;
     await withTransaction(async (tx: PoolClient) => {
       const updated = await AgrementsRepository.updateStatut({
         agrementId,
-        dateDepot,
         statut,
         tx,
       });
@@ -189,117 +293,14 @@ export const AgrementService = {
       });
     });
 
-    let eventType: AGREMENT_HISTORY_TYPE;
-    if (statut === AGREMENT_STATUT.TRANSMIS) {
-      eventType = AGREMENT_HISTORY_TYPE.TRANSMISSION;
-    } else {
-      eventType = AGREMENT_HISTORY_TYPE.STATUT_CHANGE;
-    }
-
     await AgrementService.trackEvent({
       agrementId,
       source: "usager",
-      type: eventType,
+      type: AGREMENT_HISTORY_TYPE.STATUT_CHANGE,
       typePrecision: statut,
       usagerUserId: Number(usagerUserId),
     });
 
-    if (statut === AGREMENT_STATUT.TRANSMIS) {
-      const email = await AgrementsRepository.getUserMail(agrementId);
-      const date = new Date().toLocaleDateString("fr-FR", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      });
-
-      let organismeName = "";
-      let siret = "";
-      let nomObtentionRegion = null;
-      let emailRegion: string | null = null;
-
-      try {
-        const organisme: OrganismeDto | null = await Organisme.getOne({
-          "o.id": agrement.organismeId,
-        });
-
-        if (!organisme) {
-          log.w(`Organisme introuvable pour agrementId=${agrementId}`);
-        } else if (
-          organisme.typeOrganisme === ORGANISME_TYPE.PERSONNE_MORALE &&
-          organisme.personneMorale
-        ) {
-          organismeName = organisme.personneMorale.raisonSociale || "";
-          siret = organisme.personneMorale.siret || "";
-        } else if (
-          organisme.typeOrganisme === ORGANISME_TYPE.PERSONNE_PHYSIQUE &&
-          organisme.personnePhysique
-        ) {
-          organismeName =
-            organisme.personnePhysique.nomUsage?.trim() ||
-            organisme.personnePhysique.nomNaissance ||
-            "";
-          siret = organisme.personnePhysique.siret || "";
-        }
-
-        const codeObtentionRegion = agrement.regionObtention || null;
-        if (codeObtentionRegion) {
-          const region = await Region.fetchOne(codeObtentionRegion);
-          nomObtentionRegion = region.text;
-          emailRegion = await getEmailRegion(codeObtentionRegion);
-        }
-      } catch (e) {
-        log.w(
-          "Impossible d'envoyer l'email à la région : informations manquantes ou erreur lors de la récupération. AgrementId=" +
-            agrementId,
-          e,
-        );
-      }
-
-      if (emailRegion) {
-        try {
-          const mailToSend =
-            agrement.statut === AGREMENT_STATUT.BROUILLON
-              ? // Première Transmission
-                AgrementMailAdmin.sendStatutTransmisRegionMail({
-                  agrementId,
-                  date,
-                  email: emailRegion,
-                  organismeName,
-                  siret,
-                })
-              : // Transmission après demande de modification
-                AgrementMailAdmin.sendStatutModificationTransmisRegionMail({
-                  agrementId,
-                  email: emailRegion,
-                  organismeName,
-                });
-          await mailService.send(mailToSend);
-        } catch (e) {
-          log.w("Erreur lors de l'envoi de l'email à la région", e);
-        }
-      }
-      // Envoie de mail à l'OVA uniquement lors de la première transmission
-      if (agrement.statut !== AGREMENT_STATUT.BROUILLON) {
-        return true;
-      }
-
-      if (!email) {
-        log.w("Aucun email trouvé pour l'agrément", agrementId);
-        return true;
-      }
-
-      try {
-        await mailService.send(
-          AgrementMailUsagers.sendStatutTransmisMail({
-            date,
-            email,
-            regionDreets: nomObtentionRegion,
-          }),
-        );
-      } catch (e) {
-        log.w("Erreur lors de l'envoi de l'email de transmission", e);
-      }
-    }
     return true;
   },
   async updateSvaTimer({

--- a/packages/frontend-usagers/src/components/agrement/synthese.vue
+++ b/packages/frontend-usagers/src/components/agrement/synthese.vue
@@ -103,7 +103,7 @@
       :disabled="
         !(coordonneesValid && projetValid && dossierValid && bilanValid)
       "
-      @click.prevent="onNext"
+      @click.prevent="transmitAgrement"
       >Confirmer ma demande d'agrément</DsfrButton
     >
   </div>
@@ -120,6 +120,8 @@ const props = defineProps({
   modifiable: { type: Boolean, default: true },
   cdnUrl: { type: String, required: true },
 });
+
+const emit = defineEmits(["update"]);
 
 const expandedIndex = ref<number>(-1);
 const coordonneesValid = ref<boolean>(false);
@@ -155,46 +157,8 @@ watch(
   { immediate: true },
 );
 
-const agrementStore = useAgrementStore();
-const { agrementCourant } = storeToRefs(agrementStore);
-
-const toaster = useToaster();
-
-const log = logger("components/agrement/synthese.vue");
-
-async function onNext() {
-  if (!agrementCourant.value?.id) {
-    toaster.error({
-      description: "Aucun agrément trouvé. Veuillez réessayer.",
-      role: "alert",
-    });
-
-    return;
-  }
-  try {
-    const stepDemandeTransmise =
-      props.initAgrement.statut === AGREMENT_STATUT.BROUILLON ? 0 : 1;
-    const success = await agrementStore.changeStatutAgrement({
-      agrementId: props.initAgrement?.id,
-      statut: AGREMENT_STATUT.TRANSMIS,
-    });
-    if (success) {
-      navigateTo(`/demande-agrement-transmise?step=${stepDemandeTransmise}`);
-    } else {
-      toaster.error({
-        description:
-          "Erreur lors de la transmission de votre demande. Veuillez réessayer.",
-        role: "alert",
-      });
-    }
-  } catch (err) {
-    log.w("Erreur lors de la transmission de la demande d'agrément", err);
-    toaster.error({
-      description:
-        "Erreur lors de la transmission de votre demande. Veuillez réessayer.",
-      role: "alert",
-    });
-  }
+async function transmitAgrement() {
+  emit("update");
 }
 
 function onModifierCoordonnees() {

--- a/packages/frontend-usagers/src/pages/agrement/[[agrementId]].vue
+++ b/packages/frontend-usagers/src/pages/agrement/[[agrementId]].vue
@@ -99,6 +99,7 @@
               :init-agrement="agrementStore.agrementEnTraitement ?? {}"
               :modifiable="false"
               :cdn-url="`${config.public.backendUrl}/documents/`"
+              @update="saveAndTransmitAgrement"
             />
           </div>
         </div>
@@ -125,7 +126,7 @@ const agrementStore = useAgrementStore();
 const organismeStore = useOrganismeStore();
 const documentStore = useDocumentStore();
 const config = useRuntimeConfig();
-
+const log = logger("components/agrement/[[agrementId]].vue");
 const readOnly = false;
 
 type AgrementFormValues = Partial<AgrementDto> & {
@@ -133,6 +134,34 @@ type AgrementFormValues = Partial<AgrementDto> & {
 };
 
 const canModify = true;
+
+async function saveAndTransmitAgrement() {
+  try {
+    const stepDemandeTransmise =
+      agrementStore.agrementEnTraitement?.statut === AGREMENT_STATUT.BROUILLON
+        ? 0
+        : 1;
+    const success = await updateOrCreate({
+      statut: AGREMENT_STATUT.TRANSMIS,
+    });
+    if (success) {
+      navigateTo(`/demande-agrement-transmise?step=${stepDemandeTransmise}`);
+    } else {
+      toaster.error({
+        description:
+          "Erreur lors de la transmission de votre demande. Veuillez réessayer.",
+        role: "alert",
+      });
+    }
+  } catch (err) {
+    log.w("Erreur lors de la transmission de la demande d'agrément", err);
+    toaster.error({
+      description:
+        "Erreur lors de la transmission de votre demande. Veuillez réessayer.",
+      role: "alert",
+    });
+  }
+}
 
 async function updateOrCreate(formValues: AgrementFormValues) {
   const updatedData: AgrementFormValues = { ...formValues };
@@ -234,6 +263,7 @@ async function updateOrCreate(formValues: AgrementFormValues) {
       titleTag: "h2",
       description: "Données enregistrées avec succès !",
     });
+    return true;
   } catch (error) {
     toaster.error({
       titleTag: "h2",

--- a/packages/frontend-usagers/src/pages/mon-agrement/index.vue
+++ b/packages/frontend-usagers/src/pages/mon-agrement/index.vue
@@ -175,7 +175,7 @@ const agrementAnneeRenouvellement = computed(() => {
 });
 
 useHead({
-  title: "Déclaration de séjour détaillée | Vacances Adaptées Organisées",
+  title: "Détail de mon agrément | Vacances Adaptées Organisées",
   meta: [
     {
       name: "description",

--- a/packages/shared-bridge/src/routes/usagers/agrement/postAgrement.ts
+++ b/packages/shared-bridge/src/routes/usagers/agrement/postAgrement.ts
@@ -3,7 +3,7 @@ import * as yup from "yup";
 import type { BasicRoute, RouteResponseBody, RouteSchema } from "../../..";
 import { AGREMENT_STATUT } from "../../../constantes/agrement";
 import { FILE_CATEGORY } from "../../../constantes/file";
-import type { AgrementDto } from "../../../dto";
+import type { AgrementDto, AgrementFilesDto } from "../../../dto";
 
 export interface PostAgrementRoute extends BasicRoute {
   method: "POST";
@@ -11,6 +11,19 @@ export interface PostAgrementRoute extends BasicRoute {
   body: AgrementDto;
   response: RouteResponseBody<{ id: number | null }>;
 }
+
+const REQUIRED_FILE_CATEGORIES: FILE_CATEGORY[] = [
+  FILE_CATEGORY.PROCVERBAL,
+  FILE_CATEGORY.MOTIVATION,
+  FILE_CATEGORY.IMMATRICUL,
+  FILE_CATEGORY.ASSURRESP,
+  FILE_CATEGORY.ASSURRAPAT,
+  FILE_CATEGORY.BILANQUALITPERCEPTION,
+  FILE_CATEGORY.BILANQUALITPERSPECTIVE,
+  FILE_CATEGORY.BILANQUALITELEMARQ,
+  FILE_CATEGORY.PROJETSSEJOURSCOMPETENCESEXPERIENCE,
+  FILE_CATEGORY.PROJETSSEJOURSMESURES,
+];
 
 const requiredUnlessBrouillon = (field: yup.AnySchema) =>
   field.when("statut", {
@@ -105,21 +118,50 @@ export const PostAgrementRouteSchema: RouteSchema<PostAgrementRoute> = {
         )
         .nullable(),
     ),
-    agrementFiles: requiredUnlessBrouillon(
-      yup
-        .array(
-          yup.object({
-            category: requiredUnlessBrouillon(
-              yup
-                .mixed<FILE_CATEGORY>()
-                .oneOf(Object.values(FILE_CATEGORY))
-                .nullable(),
-            ),
-            fileUuid: requiredUnlessBrouillon(yup.string().uuid().nullable()),
+    agrementFiles: yup
+      .array(
+        yup.object({
+          category: requiredUnlessBrouillon(
+            yup
+              .mixed<FILE_CATEGORY>()
+              .oneOf(Object.values(FILE_CATEGORY))
+              .nullable(),
+          ),
+          fileUuid: requiredUnlessBrouillon(yup.string().uuid().nullable()),
+        }),
+      )
+      .nullable()
+      .when("statut", {
+        is: (val: string) =>
+          val !== AGREMENT_STATUT.BROUILLON && val !== AGREMENT_STATUT.VALIDE,
+
+        otherwise: (schema) => schema.nullable(),
+
+        then: (schema) =>
+          schema.test("required-file-categories", function (files) {
+            if (!files) {
+              return this.createError({
+                message: "Des fichiers obligatoires sont manquants",
+              });
+            }
+
+            const categories = files
+              .map((f: Partial<AgrementFilesDto>) => f.category)
+              .filter(Boolean);
+
+            const missing = REQUIRED_FILE_CATEGORIES.filter(
+              (category) => !categories.includes(category),
+            );
+
+            if (missing.length > 0) {
+              return this.createError({
+                message: `Catégories obligatoires manquantes : ${missing.join(", ")}`,
+              });
+            }
+
+            return true;
           }),
-        )
-        .nullable(),
-    ),
+      }),
     agrementSejours: requiredUnlessBrouillon(
       yup
         .array(
@@ -144,19 +186,17 @@ export const PostAgrementRouteSchema: RouteSchema<PostAgrementRoute> = {
         )
         .nullable(),
     ),
-    animationAutre: requiredUnlessBrouillon(yup.string().nullable()),
+    animationAutre: yup.string().nullable(),
     bilanAucunChangementEvolution: requiredUnlessBrouillon(
       yup.boolean().nullable(),
     ),
     bilanChangementEvolution: requiredUnlessBrouillon(yup.string().nullable()),
-    bilanFinancierCommentaire: requiredUnlessBrouillon(yup.string().nullable()),
+    bilanFinancierCommentaire: yup.string().nullable(),
     bilanFinancierComparatif: requiredUnlessBrouillon(yup.string().nullable()),
     bilanFinancierComptabilite: requiredUnlessBrouillon(
       yup.string().nullable(),
     ),
-    bilanFinancierRessourcesHumaines: requiredUnlessBrouillon(
-      yup.string().nullable(),
-    ),
+    bilanFinancierRessourcesHumaines: yup.string().nullable(),
     bilanQualElementsMarquants: requiredUnlessBrouillon(
       yup.string().nullable(),
     ),
@@ -164,32 +204,32 @@ export const PostAgrementRouteSchema: RouteSchema<PostAgrementRoute> = {
       yup.string().nullable(),
     ),
     bilanQualPerspectiveEvol: requiredUnlessBrouillon(yup.string().nullable()),
-    budgetComplement: requiredUnlessBrouillon(yup.string().nullable()),
+    budgetComplement: yup.string().nullable(),
     budgetGestionPerso: requiredUnlessBrouillon(yup.string().nullable()),
-    budgetPaiementSecurise: requiredUnlessBrouillon(yup.string().nullable()),
+    budgetPaiementSecurise: yup.string().nullable(),
     budgetPersoGestionComplementaire: requiredUnlessBrouillon(
       yup.string().nullable(),
     ),
-    commentaire: requiredUnlessBrouillon(yup.string().nullable()),
-    dateConfirmCompletude: requiredUnlessBrouillon(yup.date().nullable()),
-    dateDepot: requiredUnlessBrouillon(yup.date().nullable()),
-    dateObtention: requiredUnlessBrouillon(yup.date().nullable()),
+    commentaire: yup.string().nullable(),
+    dateConfirmCompletude: yup.date().nullable(),
+    dateDepot: yup.date().nullable(),
+    dateObtention: yup.date().nullable(),
     dateObtentionCertificat: requiredUnlessBrouillon(yup.date().nullable()),
-    dateVerifCompleture: requiredUnlessBrouillon(yup.date().nullable()),
-    file: requiredUnlessBrouillon(yup.mixed().nullable()),
+    dateVerifCompleture: yup.date().nullable(),
+    file: yup.mixed().nullable(),
     id: requiredUnlessBrouillon(yup.number().nullable()),
-    immatriculation: requiredUnlessBrouillon(yup.string().nullable()),
+    immatriculation: yup.string().nullable(),
     motivations: requiredUnlessBrouillon(yup.string().nullable()),
-    numero: requiredUnlessBrouillon(yup.string().nullable()),
+    numero: yup.string().nullable(),
     organismeId: requiredUnlessBrouillon(yup.number().required()),
     protocoleEvacUrg: requiredUnlessBrouillon(yup.string().nullable()),
     protocoleInfoFamille: requiredUnlessBrouillon(yup.string().nullable()),
-    protocoleMateriel: requiredUnlessBrouillon(yup.string().nullable()),
+    protocoleMateriel: yup.string().nullable(),
     protocoleRapatEtranger: requiredUnlessBrouillon(yup.string().nullable()),
     protocoleRapatUrg: requiredUnlessBrouillon(yup.string().nullable()),
-    protocoleRemboursement: requiredUnlessBrouillon(yup.string().nullable()),
+    protocoleRemboursement: yup.string().nullable(),
     regionObtention: requiredUnlessBrouillon(yup.string().nullable()),
-    sejourCommentaire: requiredUnlessBrouillon(yup.string().nullable()),
+    sejourCommentaire: yup.string().nullable(),
     sejourNbEnvisage: requiredUnlessBrouillon(yup.number().nullable()),
     sejourTypeHandicap: requiredUnlessBrouillon(
       yup.array(yup.string().nullable()).nullable(),


### PR DESCRIPTION
## Ticket(s) lié(s)
1392

## Description
Migration de la Transmission de  l'agrément côté OVA via la méthode POST plutôt  que par simple update de statut pour pouvoir passer les contrôles Yup côté Backend
Ajustement du Yup pour coller au fonctionnement des champs obligatoires et facultatifs
