### PR TITLE
fix: 1395 fix scroll sur les tabs agrements (ova)

### DIFF
--- a/packages/frontend-usagers/src/pages/mon-agrement/index.vue
+++ b/packages/frontend-usagers/src/pages/mon-agrement/index.vue
@@ -308,4 +308,13 @@ onMounted(async () => {
     text-align: center;
   }
 }
+
+/* fix un problème de hauteur au niveau des tabs > le dsfr injecte une classe --tabs-height pour calculer la hauteur du tab, mais cette valeur n'est pas correcte. On force donc la hauteur du tab à auto pour que la hauteur corresponde à son contenu */
+.fr-tabs {
+  height: auto !important;
+}
+
+.fr-tabs__panel {
+  height: auto !important;
+}
 </style>


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/browse/VAO-1395

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Corrige une erreur d'affichage sur le tab "documents" coté ova dans la partie agrement. Le contenu était coupé, c'est un soucis du dsfr d'ou les "!important". 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 
<img width="1041" height="902" alt="Capture d’écran 2026-05-12 à 14 26 12" src="https://github.com/user-attachments/assets/5f68c5a0-28d9-40ae-9364-dbe3102bc531" />


## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
