### PR TITLE
chore(infra): boost CNPG pg resources (cpu→4500m, mem→8Gi)

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -7,11 +7,11 @@ pg:
       size: "200Gi"
     resources:
       requests:
-        cpu: 3000m
-        memory: 6Gi
+        cpu: 4500m
+        memory: 8Gi
       limits:
-        cpu: 3000m
-        memory: 6Gi
+        cpu: 4500m
+        memory: 8Gi
 
 backend:
   autoscale:


### PR DESCRIPTION
## Contexte

Pic CPU à 100% sur le primary CNPG `pg-6` (ns `vao`, ovh-prod) ayant fait tomber les backends. La saturation vient de requêtes applicatives lourdes qui s'empilent sous concurrence (dashboard BO `getAdminStats` ~4s/appel, listings BO 66–113s/appel).

## Changement

Boost mesuré des ressources du cluster CNPG `pg` en prod, pour donner de la marge **en attendant** l'optimisation des requêtes :

| Ressource | Avant | Après |
|-----------|-------|-------|
| CPU (req=lim) | 3000m | 4500m |
| Mémoire (req=lim) | 6Gi | 8Gi |

QoS Guaranteed conservé (requests = limits). Vérifié côté capacité : les 3 nodes core ont la place (≈3,8–4,9 cores libres chacun), pas de risque de pod Pending.

⚠️ Le changement de ressources déclenche un rolling update CNPG (replicas puis redémarrage du primary).

## Suite (hors PR)

Correctifs applicatifs à venir : index SQL + cache sur `getAdminStats`, suppression du LEFT JOIN inutile dans les counts de listing, `jti` sur le refresh token (duplicate key `pk_session`), `statement_timeout` sur le rôle applicatif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)