### PR TITLE
chore(infra): set statement_timeout=120s sur CNPG pg (prod)

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -12,6 +12,12 @@ pg:
       limits:
         cpu: 4500m
         memory: 8Gi
+    postgresqlParameters:
+      # TimeZone repris explicitement pour ne pas le perdre au merge des values
+      TimeZone: "Europe/Paris"
+      # Garde-fou anti-saturation CPU : tue les requetes > 120s (au-dessus des
+      # listings BO legitimes ~113s). pg_dump fixe lui-meme statement_timeout=0.
+      statement_timeout: "120s"
 
 backend:
   autoscale:


### PR DESCRIPTION
## Contexte

Suite au pic CPU 100% sur le primary CNPG `pg-6` (ns `vao`, ovh-prod) qui a fait tomber les backends, on ajoute un garde-fou anti-saturation : `statement_timeout`. Aujourd'hui il vaut `0` (désactivé), donc une requête lente peut tourner indéfiniment et faire s'empiler la charge CPU.

## Changement

Ajout de `postgresqlParameters` sur le cluster CNPG `pg` en prod (`.kontinuous/env/prod/values.yaml`) :

```yaml
postgresqlParameters:
  TimeZone: "Europe/Paris"
  statement_timeout: "120s"
```

- **120s** : volontairement au-dessus des listings BO légitimes (qui montent à ~113s) pour ne tuer que les requêtes réellement bloquées/runaway, sans casser le fonctionnel existant. À resserrer une fois les requêtes lourdes optimisées.
- `pg_dump` pose lui-même `statement_timeout = 0` en début de session → **les backups ne sont pas impactés**.
- La réplication / les walsenders ne sont pas concernés par `statement_timeout`.
- `TimeZone` est repris explicitement pour éviter toute régression au merge des values (il n'est défini nulle part ailleurs côté repo).

Paramètre rechargé par CNPG sans redémarrage (SIGHUP).

## Validation

`helm template` de la chart `cnpg-cluster` avec ces valeurs → rendu attendu :

```yaml
parameters:
  TimeZone: Europe/Paris
  statement_timeout: 120s
```

## Note

PR distincte du boost de ressources (#1362). Non appliquée en live : se déploiera via le pipeline kontinuous au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)