### PR TITLE
chore: e2e check filter is checked

### DIFF
--- a/e2e/personne-physique-3-demande-sejour.spec.ts
+++ b/e2e/personne-physique-3-demande-sejour.spec.ts
@@ -1,13 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   alertLocator,
   apiGet,
+  ensureFilterIsChecked,
   loginBo,
   loginUsagers,
   logSuiteName,
   logTestName,
   logTestResult,
-  multiselectCheckboxLocator,
   waitReadyPage,
 } from "./utils/helper";
 import { getAgentDepartement75Paris, getOvaUser } from "./utils/users";
@@ -302,14 +302,9 @@ test.describe.serial(testName, () => {
       .click();
     await page.getByLabel("Nombre de lignes par page").selectOption("20");
     await page.getByRole("button", { name: "options sélectionnées" }).click();
-    await page
-      .locator(multiselectCheckboxLocator)
-      .getByText("EN COURS", { exact: true })
-      .click();
-    await page
-      .locator(multiselectCheckboxLocator)
-      .getByText("TRANSMISE", { exact: true })
-      .click();
+    await ensureFilterIsChecked(page, "EN COURS");
+    await ensureFilterIsChecked(page, "TRANSMISE");
+
     await page
       .getByRole("row", { name: `${sejour.idFonctionnelle} Musée Rodin Six` })
       .getByRole("button")

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -159,3 +159,30 @@ export function getTransportsFile() {
 export function getBasicFile() {
   return path.join(__dirname, "../data/basic-file.pdf");
 }
+
+export async function ensureFilterIsChecked(page: Page, label: string) {
+  const option = page
+    .locator(multiselectCheckboxLocator)
+    .getByText(label, { exact: true });
+  const checkbox = option.locator("input[type='checkbox']");
+
+  if ((await checkbox.count()) > 0) {
+    if (!(await checkbox.first().isChecked())) {
+      await option.click();
+    }
+    return;
+  }
+
+  const isSelected =
+    (await option.locator("[aria-checked='true']").count()) > 0 ||
+    (await option.evaluate((element) => {
+      if (element.getAttribute("aria-checked") === "true") {
+        return true;
+      }
+      return element.closest("[aria-checked='true']") !== null;
+    }));
+
+  if (!isSelected) {
+    await option.click();
+  }
+}


### PR DESCRIPTION
## Ticket(s) lié(s)

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description

Quand les tests e2e font des retry, les précedent filtre des DS sont conservé ce qui a pour conséquence de faire echoué le test car on re-clique sur le filtre "TRANSMISE" ce qui le décoche a tord.

## Screenshot / liens loom 

## Check-list

 - [ ] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [ ] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
