### PR TITLE
fix: 1412: normalise le nom des fichiers uploades en supprimant les caractères spéciaux

### DIFF
--- a/packages/backend/src/__tests__/usagers/documents.test.ts
+++ b/packages/backend/src/__tests__/usagers/documents.test.ts
@@ -45,6 +45,9 @@ afterAll(async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  (getFileTypeFromBuffer as jest.Mock).mockImplementation((buf: Buffer) =>
+    Promise.resolve(detectFileType(buf)),
+  );
 });
 
 describe("GET /documents/:uuid", () => {

--- a/packages/backend/src/__tests__/usagers/documents.test.ts
+++ b/packages/backend/src/__tests__/usagers/documents.test.ts
@@ -229,3 +229,24 @@ describe("POST /documents", () => {
     expect(response.body.name).toBe("FileIsTooLargeError");
   });
 });
+
+describe("POST /documents - encodage du nom de fichier", () => {
+  it("devrait stocker le nom avec accents correctement normalisé (NFC)", async () => {
+    const user = await createUsagersUser();
+    const pdfBuffer = await createMinimalPdf();
+
+    const response = await request(getFoAppHelper(user))
+      .post("/documents")
+      .field("category", "declaration")
+      .attach("file", pdfBuffer, "déclaration-été.pdf");
+
+    expect(response.status).toBe(200);
+    expect(response.body.uuid).toBeDefined();
+
+    const metaData = await DocumentService.getFileMetaData(response.body.uuid);
+
+    expect(metaData).not.toBeNull();
+    expect(metaData!.name).toEqual("declaration-ete.pdf");
+    expect(metaData!.name).not.toEqual("dÃ©claration-Ã©tÃ©.pdf");
+  });
+});

--- a/packages/backend/src/controllers/documents/upload.ts
+++ b/packages/backend/src/controllers/documents/upload.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 
 import * as Sentry from "@sentry/node";
+import { normalizeFilename } from "@vao/shared-bridge";
 import type { NextFunction, Response } from "express";
 import { PDFDocument } from "pdf-lib";
 
@@ -33,9 +34,7 @@ export default async function upload(
 
   try {
     const { path, originalname } = file;
-    const filename = Buffer.from(originalname, "latin1")
-      .toString("utf8")
-      .normalize("NFC");
+    const filename = normalizeFilename(originalname);
     const fileBuffer = await fs.readFile(path);
     const fileType = await getFileTypeFromBuffer(fileBuffer);
 

--- a/packages/backend/src/controllers/documents/upload.ts
+++ b/packages/backend/src/controllers/documents/upload.ts
@@ -32,7 +32,10 @@ export default async function upload(
   }
 
   try {
-    const { path, originalname: filename } = file;
+    const { path, originalname } = file;
+    const filename = Buffer.from(originalname, "latin1")
+      .toString("utf8")
+      .normalize("NFC");
     const fileBuffer = await fs.readFile(path);
     const fileType = await getFileTypeFromBuffer(fileBuffer);
 

--- a/packages/shared-bridge/src/utils/index.ts
+++ b/packages/shared-bridge/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./date";
 export * from "./errors";
 export * from "./file";
 export * from "./normalizeAdresse";
+export * from "./normalizeFilename";
 export * from "./request";
 export * from "./siret";
 export * from "./stringUtils";

--- a/packages/shared-bridge/src/utils/normalizeFilename.spec.ts
+++ b/packages/shared-bridge/src/utils/normalizeFilename.spec.ts
@@ -1,0 +1,42 @@
+import { normalizeFilename } from "./normalizeFilename";
+
+function simulateMulterCorruption(utf8string: string): string {
+  const bytes = new TextEncoder().encode(utf8string);
+  return Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+}
+
+describe("normalizeFilename", () => {
+  it("should return a plain filename unchanged", () => {
+    expect(normalizeFilename("document.pdf")).toEqual("document.pdf");
+  });
+
+  it("should remove accents from a corrupted multer filename", () => {
+    const corrupted = simulateMulterCorruption("déclaration-été.pdf");
+    expect(normalizeFilename(corrupted)).toEqual("declaration-ete.pdf");
+  });
+
+  it("should replace spaces with hyphens", () => {
+    expect(normalizeFilename("mon document final.pdf")).toEqual(
+      "mon-document-final.pdf",
+    );
+  });
+
+  it("should collapse consecutive hyphens", () => {
+    expect(normalizeFilename("fichier  avec   espaces.pdf")).toEqual(
+      "fichier-avec-espaces.pdf",
+    );
+  });
+
+  it("should preserve the file extension", () => {
+    expect(normalizeFilename("rapport.final.pdf")).toEqual("rapport.final.pdf");
+  });
+
+  it("should handle a filename with no extension", () => {
+    const corrupted = simulateMulterCorruption("réunion");
+    expect(normalizeFilename(corrupted)).toEqual("reunion");
+  });
+
+  it("should handle an empty string", () => {
+    expect(normalizeFilename("")).toEqual("");
+  });
+});

--- a/packages/shared-bridge/src/utils/normalizeFilename.ts
+++ b/packages/shared-bridge/src/utils/normalizeFilename.ts
@@ -1,0 +1,18 @@
+export function normalizeFilename(filename: string): string {
+  const decoded = new TextDecoder("utf-8").decode(
+    Uint8Array.from(filename, (c) => c.charCodeAt(0)),
+  );
+
+  const lastDot = decoded.lastIndexOf(".");
+  const name = lastDot !== -1 ? decoded.slice(0, lastDot) : decoded;
+  const extension = lastDot !== -1 ? decoded.slice(lastDot) : "";
+
+  const sanitized = name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return sanitized + extension;
+}


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336?selectedIssue=VAO-1412

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Nettoie le nom des fichiers uploadés. 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 
<img width="871" height="169" alt="Capture d’écran 2026-06-08 à 18 38 25" src="https://github.com/user-attachments/assets/ea9e3cd8-36bd-4c44-95c6-ff86ede8332c" />


## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
