### PR TITLE
Fix/renouvellement regressions

### DIFF
--- a/packages/backend/src/__tests__/usagers/agrements.test.ts
+++ b/packages/backend/src/__tests__/usagers/agrements.test.ts
@@ -768,7 +768,48 @@ describe("POST /agrements", () => {
     expect(response.status).toBe(404);
     expect(response.body.name).toEqual(ERRORS_COMMON.PATH_NOT_FOUND);
   });
-  it("retourne une erreur 400 si une personne morale transmet un agrément sans procès verbal", async () => {
+  it("retourne une erreur 400 si une personne morale soumet sans procès verbal lors d'un A_COMPLETER", async () => {
+    const frontUser = await createUsagersUser();
+    const organismeId = await createOrganisme({
+      organisme: {
+        raisonSociale: "ACME Corp",
+        siret: "12345678900000",
+      },
+      typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
+      userId: frontUser.id,
+    });
+
+    // Création initiale avec procès-verbal pour que createAgrement passe
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+
+    // Soumission sans procès-verbal en statut A_COMPLETER
+    const agrementDataWithoutProcVerbal = {
+      ...agrementData,
+      agrementFiles: (agrementData.agrementFiles ?? []).filter(
+        (file) => file.category !== FILE_CATEGORY.PROCVERBAL,
+      ),
+    };
+
+    const response = await request(getFoAppHelper(frontUser))
+      .post(`/agrements/`)
+      .send({
+        ...agrementDataWithoutProcVerbal,
+        id: agrementId,
+        statut: AGREMENT_STATUT.A_COMPLETER,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain("procès verbal");
+  });
+
+  it("retourne une erreur 400 si une personne morale soumet sans procès verbal lors d'un EN_INSTRUCTION", async () => {
     const frontUser = await createUsagersUser();
     const organismeId = await createOrganisme({
       organisme: {
@@ -783,6 +824,10 @@ describe("POST /agrements", () => {
       organismeId,
       statut: AGREMENT_STATUT.BROUILLON,
     });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
 
     const agrementDataWithoutProcVerbal = {
       ...agrementData,
@@ -791,17 +836,51 @@ describe("POST /agrements", () => {
       ),
     };
 
+    const response = await request(getFoAppHelper(frontUser))
+      .post(`/agrements/`)
+      .send({
+        ...agrementDataWithoutProcVerbal,
+        id: agrementId,
+        statut: AGREMENT_STATUT.EN_INSTRUCTION,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain("procès verbal");
+  });
+
+  it("retourne une erreur 400 si une personne morale soumet sans procès verbal lors d'un A_CORRIGER", async () => {
+    const frontUser = await createUsagersUser();
+    const organismeId = await createOrganisme({
+      organisme: {
+        raisonSociale: "ACME Corp",
+        siret: "12345678900000",
+      },
+      typeOrganisme: ORGANISME_TYPE.PERSONNE_MORALE,
+      userId: frontUser.id,
+    });
+
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
     const agrementId = await createAgrement({
-      agrement: agrementDataWithoutProcVerbal,
+      agrement: agrementData,
       organismeId,
     });
+
+    const agrementDataWithoutProcVerbal = {
+      ...agrementData,
+      agrementFiles: (agrementData.agrementFiles ?? []).filter(
+        (file) => file.category !== FILE_CATEGORY.PROCVERBAL,
+      ),
+    };
 
     const response = await request(getFoAppHelper(frontUser))
       .post(`/agrements/`)
       .send({
         ...agrementDataWithoutProcVerbal,
         id: agrementId,
-        statut: AGREMENT_STATUT.TRANSMIS,
+        statut: AGREMENT_STATUT.A_CORRIGER,
       });
 
     expect(response.status).toBe(400);

--- a/packages/backend/src/usagers/agrements/agrements.service.ts
+++ b/packages/backend/src/usagers/agrements/agrements.service.ts
@@ -29,6 +29,16 @@ import { AgrementsRepository } from "./agrements.repository";
 
 const log = logger(module.filename);
 
+// Statuts pour lesquels l'OVA soumet ou modifie un dossier.
+// PRIS_EN_CHARGE et REFUSE sont pas inclus pcq ce sont des statuts DREETS,
+// l'OVA ne soumet aucune modification à ces étapes.
+const STATUTS_NECESSITANT_PROCES_VERBAL = new Set([
+  AGREMENT_STATUT.TRANSMIS,
+  AGREMENT_STATUT.A_COMPLETER,
+  AGREMENT_STATUT.EN_INSTRUCTION,
+  AGREMENT_STATUT.A_CORRIGER,
+]);
+
 async function getEmailRegion(codeRegion: string): Promise<string | null> {
   const fiche = await TerritoireService.readFicheIdByTerCode(codeRegion);
   if (!fiche?.id) return null;
@@ -143,12 +153,18 @@ export const AgrementService = {
 
     const isPersonneMorale =
       organisme.typeOrganisme === ORGANISME_TYPE.PERSONNE_MORALE;
-    const isAgrementBrouillon = agrement.statut === AGREMENT_STATUT.BROUILLON;
+
+    const isStatutNecessitantProcesVerbal =
+      STATUTS_NECESSITANT_PROCES_VERBAL.has(agrement.statut!);
     const hasProcesVerbal = agrement.agrementFiles?.some(
       (file) => file.category === FILE_CATEGORY.PROCVERBAL,
     );
 
-    if (isPersonneMorale && !isAgrementBrouillon && !hasProcesVerbal) {
+    if (
+      isPersonneMorale &&
+      isStatutNecessitantProcesVerbal &&
+      !hasProcesVerbal
+    ) {
       log.w(
         "Validation échouée : procès verbal manquant pour personne morale",
         { agrementId: agrement.id },

--- a/packages/frontend-usagers/src/components/agrement/projets/organisationTransports.vue
+++ b/packages/frontend-usagers/src/components/agrement/projets/organisationTransports.vue
@@ -80,30 +80,24 @@ const filesProjetsSejoursOrgaTransports = ref(
 
 const validationSchema = yup.object({
   statut: yup.mixed().oneOf(Object.values(AGREMENT_STATUT)).required(),
-  transportAllerRetour:
-    props.initAgrement.statut === AGREMENT_STATUT.BROUILLON
-      ? yup.string().nullable()
-      : requiredUnlessBrouillon(
-          yup
-            .string()
-            .min(
-              1,
-              "Veuillez indiquer le moyen de transport aller-retour prévu. Minimum 1 caractère.",
-            )
-            .nullable(),
-        ),
-  transportSejour:
-    props.initAgrement.statut === AGREMENT_STATUT.BROUILLON
-      ? yup.string().nullable()
-      : requiredUnlessBrouillon(
-          yup
-            .string()
-            .min(
-              1,
-              "Veuillez indiquer le moyen de transport prévu pour le séjour. Minimum 1 caractère.",
-            )
-            .nullable(),
-        ),
+  transportAllerRetour: requiredUnlessBrouillon(
+    yup
+      .string()
+      .min(
+        1,
+        "Veuillez indiquer le moyen de transport aller-retour prévu. Minimum 1 caractère.",
+      )
+      .nullable(),
+  ),
+  transportSejour: requiredUnlessBrouillon(
+    yup
+      .string()
+      .min(
+        1,
+        "Veuillez indiquer le moyen de transport prévu pour le séjour. Minimum 1 caractère.",
+      )
+      .nullable(),
+  ),
 });
 
 const initialValues = {

--- a/packages/shared-bridge/src/routes/usagers/agrement/postAgrement.ts
+++ b/packages/shared-bridge/src/routes/usagers/agrement/postAgrement.ts
@@ -33,6 +33,22 @@ const requiredUnlessBrouillon = (field: yup.AnySchema) =>
     then: (schema) => schema.required("Champ obligatoire"),
   });
 
+// NOTE : on ne peut pas passer yup.string().min(20).nullable() directement à
+// requiredUnlessBrouillon pcq les contraintes de chaînage yup sont cumulatives.
+// requiredWithMinCaractersUnlessBrouillon applique .min() uniquement dans la branche `then`,
+// garantissant que la contrainte ne s'active qu'hors BROUILLON et VALIDE.
+const requiredWithMinCaractersUnlessBrouillon = (
+  field: yup.StringSchema<string | null | undefined>,
+  min: number,
+  message: string = `Minimum ${min} caractères.`,
+) =>
+  field.when("statut", {
+    is: (val: string) =>
+      val !== AGREMENT_STATUT.BROUILLON && val !== AGREMENT_STATUT.VALIDE,
+    otherwise: (schema) => schema.nullable(),
+    then: (schema) => schema.required("Champ obligatoire").min(min, message),
+  });
+
 const currentYear = new Date().getFullYear();
 
 const adresseSchema = yup.object({
@@ -190,10 +206,12 @@ export const PostAgrementRouteSchema: RouteSchema<PostAgrementRoute> = {
     bilanAucunChangementEvolution: requiredUnlessBrouillon(
       yup.boolean().nullable(),
     ),
-    bilanChangementEvolution: requiredUnlessBrouillon(yup.string().nullable()),
+    bilanChangementEvolution: yup.string().nullable(),
     bilanFinancierCommentaire: yup.string().nullable(),
-    bilanFinancierComparatif: requiredUnlessBrouillon(
-      yup.string().min(20, "Minimum 20 caractères.").nullable(),
+    bilanFinancierComparatif: requiredWithMinCaractersUnlessBrouillon(
+      yup.string().nullable(),
+      20,
+      "Minimum 20 caractères.",
     ),
     bilanFinancierComptabilite: requiredUnlessBrouillon(
       yup.string().nullable(),


### PR DESCRIPTION
## Ticket(s) lié(s)

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Corrections de regressions sur la partie renouvellement agrement:
- bilanFinancierComparatif et transportAllerRetour transportSejour validation
-regression causée par le check proces verbal via le ticket 1385:
lors du renseignement de la fiche organisateur en tant que PM, lorsqu'on valide l'etape agrement on est bloqué avec l'erreur "Validation échouée : procès verbal manquant pour personne morale". C'est parce que le service save (agrement/usagers) est appellé à cette étape. La condition initiale (`if (isPersonneMorale && !isAgrementBrouillon && !hasProcesVerbal`) était trop large pour le cadre d'une inscription suivie du renseignement de la fiche organisateur. Il faut préciser la condition pour cibler les cas réels ou le proces verbal est exigé. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
