### PR TITLE
fix: 1406 remplace alert par un toaster etape un renouvellement (UI)

### DIFF
--- a/packages/frontend-usagers/src/components/agrement/coordonnees.vue
+++ b/packages/frontend-usagers/src/components/agrement/coordonnees.vue
@@ -188,9 +188,18 @@ async function validatePersonne(
         return data;
       } catch (err: any) {
         console.error("Erreur lors de la sauvegarde :", err);
-        errorRef.value =
-          "Erreur lors de la sauvegarde : " +
-          (err?.message || "Erreur inconnue.");
+
+        const status = err?.status ?? err?.response?.status;
+        const description =
+          status === 403
+            ? "Vous n'avez pas les droits pour effectuer cette action."
+            : "Un problème est survenu lors de la sauvegarde. Veuillez réessayer.";
+
+        toaster.error({
+          titleTag: "h2",
+          description,
+        });
+
         return null;
       }
     }


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/browse/VAO-1406?atlOrigin=eyJpIjoiODRmYjNmMDFmNmExNGNmYTlmOWU0YjQxZWNmMjIyZjciLCJwIjoiaiJ9

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Remplacement d'une alerte par un toaster pour rendre l'ui plus cohérente. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 
<img width="1456" height="818" alt="Capture d’écran 2026-06-18 à 11 59 10" src="https://github.com/user-attachments/assets/0bda7739-6214-4ba1-bd18-af51df068eb9" />


## Check-list

 - [ ] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [ ] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
