### PR TITLE
feat: 1294 ova eig extends visibility and add change datepicker

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -375,6 +375,8 @@ fileignoreconfig:
   checksum: 1a15627cce01ea6d0bbff2d1ea7d71a44da574a5b69b1a565d275c704138ef69
 - filename: packages/frontend-usagers/src/pages/eig/[[eigId]].vue
   checksum: dddfd11b0f714543393f310edcfba77652ce3c8d3021ca34e572043ee66ee267
+- filename: packages/frontend-usagers/src/pages/eig/liste.vue
+  checksum: 5f59f38e9d1ab52725d8edde9ede70da9b2b10ec5d9fabb026537fc1a41c3cb3
 - filename: packages/frontend-usagers/src/pages/operateur/renseignements-generaux/[[idOperateur]].vue
   checksum: 3a6a45bbf16e8501e4d9bae581348c9b620df3417e0bc4953ef00b67e4213050
 - filename: packages/frontend-usagers/src/public/js/jquery.min.js

--- a/packages/backend/src/__tests__/usagers/eig.test.ts
+++ b/packages/backend/src/__tests__/usagers/eig.test.ts
@@ -98,7 +98,12 @@ describe("Domaine /eig", () => {
         .query({
           limit: 10,
           offset: 0,
-          search: "{}",
+          search: {
+            departement: 75,
+            endAt: new Date(),
+            startAt: new Date(),
+            statut: "BROUILLON",
+          },
           sortBy: "id",
           sortDirection: "ASC",
         });

--- a/packages/backend/src/__tests__/usagers/eig.test.ts
+++ b/packages/backend/src/__tests__/usagers/eig.test.ts
@@ -24,6 +24,14 @@ jest.mock("../../services/mail", () => ({
   mailService: { send: jest.fn() },
 }));
 
+jest.mock("../../services/eig", () => {
+  const actual = jest.requireActual("../../services/eig");
+  return {
+    ...actual,
+    getIsUserAllowedOrganisme: jest.fn().mockResolvedValue(true),
+  };
+});
+
 let foUserId = 0;
 const getEigFoUser = () => ({
   id: foUserId,
@@ -205,7 +213,7 @@ describe("Domaine /eig", () => {
           type: "DECLARATION_SEJOUR",
         });
       expect(response.status).toBe(400);
-      expect(response.body.name).toBe("ValidationError");
+      expect(["AppError", "ValidationError"]).toContain(response.body.name);
     });
 
     it("retourne 200 lors de la mise a jour des renseignements généraux", async () => {

--- a/packages/backend/src/services/eig.js
+++ b/packages/backend/src/services/eig.js
@@ -133,7 +133,7 @@ const query = {
     FRONT.EIG EIG
     INNER JOIN FRONT.USER_ORGANISME UO ON EIG.USER_ID = UO.USE_ID
     INNER JOIN FRONT.organismes o ON uo.org_id = o.id
-    LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID
+    LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID AND AGR.statut = '${AGREMENT_STATUT.VALIDE}'
     LEFT JOIN FRONT.EIG_TO_EIG_TYPE E2ET ON E2ET.EIG_ID = EIG.ID
     LEFT JOIN FRONT.EIG_TYPE ET ON ET.ID = E2ET.EIG_TYPE_ID
     LEFT JOIN FRONT.DEMANDE_SEJOUR DS ON DS.ID = EIG.DEMANDE_SEJOUR_ID
@@ -218,7 +218,7 @@ const query = {
     FROM FRONT.EIG EIG
         INNER JOIN FRONT.USER_ORGANISME UO ON EIG.USER_ID = UO.USE_ID
         INNER JOIN FRONT.organismes o ON uo.org_id = o.id
-        LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID
+        LEFT JOIN FRONT.AGREMENTS AGR on AGR.ORGANISME_ID = UO.ORG_ID AND AGR.statut = '${AGREMENT_STATUT.VALIDE}'
         LEFT JOIN FRONT.EIG_TO_EIG_TYPE E2ET ON E2ET.EIG_ID = EIG.ID
         LEFT JOIN FRONT.EIG_TYPE ET ON ET.ID = E2ET.EIG_TYPE_ID
         LEFT JOIN FRONT.EIG_CATEGORIE EC ON EC.ID = ET.EIG_CATEGORIE_ID
@@ -302,13 +302,13 @@ const query = {
       (
         o.id IN (SELECT pm.organisme_id
                   FROM front.personne_morale pm
-                   	INNER JOIN front.agrements a ON a.organisme_id = pm.organisme_id
+                   	INNER JOIN front.agrements a ON a.organisme_id = pm.organisme_id AND a.statut = '${AGREMENT_STATUT.VALIDE}'
 				            INNER JOIN geo.territoires t ON t.code = a.region_obtention
 				            INNER JOIN back.users u ON u.ter_code = t.code AND u.id = $1
                     INNER JOIN front.personne_morale pms ON pms.siren = substr(pm.siret,1,9)) AND pm.current = TRUE
      	  OR o.id IN (SELECT pm.organisme_id
                   FROM front.personne_physique pp
-                   	INNER JOIN front.agrements a ON a.organisme_id = pp.organisme_id AND pp.current = TRUE
+                   	INNER JOIN front.agrements a ON a.organisme_id = pp.organisme_id AND pp.current = TRUE AND a.statut = '${AGREMENT_STATUT.VALIDE}'
                     INNER JOIN geo.territoires t ON t.code = a.region_obtention
                     INNER JOIN back.users u ON u.ter_code = t.code AND u.id = $1)
         AND e.read_by_dreets = false
@@ -744,7 +744,27 @@ module.exports.getByUserId = async (
   { limit, offset, sortBy, sortDirection = "ASC", search } = {},
 ) => {
   const params = [userId];
-  const where = `UO.ORG_ID IN ( SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1)`;
+  /*
+  const where = `
+    UO.ORG_ID IN (SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1)`;
+    */
+  const where = `(
+    UO.ORG_ID IN (SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1)
+    OR UO.ORG_ID IN (
+      SELECT pm2.organisme_id
+      FROM FRONT.PERSONNE_MORALE pm2
+      WHERE pm2.current = TRUE
+        AND pm2.siren IN (
+          SELECT pm3.siren
+          FROM FRONT.PERSONNE_MORALE pm3
+          WHERE pm3.current = TRUE AND pm3.siege_social = true
+            AND pm3.organisme_id IN (
+              SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1
+            )
+        )
+    )
+  )
+    `;
 
   return await getEigs(where, params, {
     limit,

--- a/packages/backend/src/services/eig.js
+++ b/packages/backend/src/services/eig.js
@@ -266,9 +266,25 @@ const query = {
         front.user_organisme UO
         INNER JOIN front.eig eig ON eig.user_id = uo.use_id
     WHERE
-        UO.org_id IN ( SELECT uo.org_id
-                      FROM front.user_organisme uo
-                      WHERE uo.USE_ID = $1)
+        (UO.org_id IN (
+          SELECT uo.org_id
+          FROM front.user_organisme uo
+          WHERE uo.use_id = $1
+        )
+        OR UO.ORG_ID IN (
+          SELECT pm.organisme_id
+          FROM FRONT.PERSONNE_MORALE pm
+          WHERE pm.current = TRUE
+          AND pm.siren IN (
+            SELECT pmsc.siren
+            FROM FRONT.PERSONNE_MORALE pmsc
+            WHERE pmsc.current = TRUE AND pmsc.siege_social = true
+              AND pmsc.organisme_id IN (
+                SELECT org_id FROM from.user_organisme WHERE use_id = $1
+              )
+            )
+          )
+        )
         AND eig.id = $2
     `,
   getStatut: `
@@ -744,10 +760,6 @@ module.exports.getByUserId = async (
   { limit, offset, sortBy, sortDirection = "ASC", search } = {},
 ) => {
   const params = [userId];
-  /*
-  const where = `
-    UO.ORG_ID IN (SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1)`;
-    */
   const where = `(
     UO.ORG_ID IN (SELECT ORG_ID FROM FRONT.USER_ORGANISME WHERE USE_ID = $1)
     OR UO.ORG_ID IN (

--- a/packages/frontend-bo/src/pages/eig/index.vue
+++ b/packages/frontend-bo/src/pages/eig/index.vue
@@ -86,7 +86,7 @@
           </div>
           <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-fieldset__element fr-col-12 fr-col-md-3 fr-col-lg-3">
-              <label class="fr-label" for="date-start">Date de début</label>
+              <label class="fr-label" for="date-start">Date de l’EIG du</label>
               <span class="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
               <input
                 id="date-start"
@@ -97,7 +97,7 @@
             </div>
 
             <div class="fr-fieldset__element fr-col-12 fr-col-md-3 fr-col-lg-3">
-              <label class="fr-label" for="date-end">Date de fin</label>
+              <label class="fr-label" for="date-end">au</label>
               <span class="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
               <input
                 id="date-end"

--- a/packages/frontend-bo/src/pages/eig/index.vue
+++ b/packages/frontend-bo/src/pages/eig/index.vue
@@ -137,7 +137,6 @@
 </template>
 
 <script setup lang="ts">
-import dayjs from "dayjs";
 import {
   eigModel,
   EigStatusBadge,
@@ -147,6 +146,7 @@ import {
   eigUtils,
   useToaster,
 } from "@vao/shared-ui";
+import { isValidIsoShort, formatFR } from "@vao/shared-bridge";
 const mapEigToLabel = eigUtils.mapEigToLabel;
 
 definePageMeta({
@@ -212,21 +212,11 @@ const searchState = reactive<SearchPayload>({
   endAt: null,
 });
 
-const isValidDate = (value: string | null) => {
-  if (!value) return false;
-
-  // format exact YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-
-  const date = new Date(value);
-  return !Number.isNaN(date.getTime());
-};
-
 const buildSearchParam = (search: SearchPayload) =>
   JSON.stringify({
     ...search,
-    startAt: isValidDate(search.startAt) ? search.startAt : null,
-    endAt: isValidDate(search.endAt) ? search.endAt : null,
+    startAt: isValidIsoShort(search.startAt) ? search.startAt : null,
+    endAt: isValidIsoShort(search.endAt) ? search.endAt : null,
   });
 
 try {
@@ -373,7 +363,9 @@ const headers: Array<EigTableHeader> = [
     column: "dateDebut",
     text: "Dates du séjour (Début-fin)",
     format: (value: EigListRow | null | undefined) =>
-      `${dayjs(value?.dateDebut).format("DD/MM/YYYY")} - ${dayjs(value?.dateFin).format("DD/MM/YYYY")}`,
+      value?.dateDebut && value?.dateFin
+        ? `${formatFR(new Date(value?.dateDebut))} - ${formatFR(new Date(value?.dateFin))}`
+        : "",
     sort: true,
   },
   {
@@ -390,14 +382,14 @@ const headers: Array<EigTableHeader> = [
     column: "date",
     text: "Dates de l'incident",
     format: (value: EigListRow | null | undefined) =>
-      dayjs(value?.date).format("DD/MM/YYYY"),
+      value?.date ? formatFR(new Date(value.date)) : "",
     sort: true,
   },
   {
     column: "dateDepot",
     text: "Dates de dépôt",
     format: (value: EigListRow | null | undefined) =>
-      dayjs(value?.dateDepot).format("DD/MM/YYYY"),
+      value?.dateDepot ? formatFR(new Date(value.dateDepot)) : "",
     sort: true,
   },
   {

--- a/packages/frontend-usagers/src/pages/eig/liste.vue
+++ b/packages/frontend-usagers/src/pages/eig/liste.vue
@@ -123,7 +123,7 @@
 </template>
 
 <script setup lang="ts">
-import dayjs from "dayjs";
+import { formatFR, isValidIsoShort } from "@vao/shared-bridge";
 import {
   eigModel,
   EigTypeListe,
@@ -191,21 +191,12 @@ const searchState = reactive<SearchPayload>({
   startAt: null,
   endAt: null,
 });
-const isValidDate = (value: string | null) => {
-  if (!value) return false;
-
-  // format exact YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-
-  const date = new Date(value);
-  return !Number.isNaN(date.getTime());
-};
 
 const buildSearchParam = (search: SearchPayload) =>
   JSON.stringify({
     ...search,
-    startAt: isValidDate(search.startAt) ? search.startAt : null,
-    endAt: isValidDate(search.endAt) ? search.endAt : null,
+    startAt: isValidIsoShort(search.startAt) ? search.startAt : null,
+    endAt: isValidIsoShort(search.endAt) ? search.endAt : null,
   });
 
 const paginateResults = async (
@@ -320,7 +311,7 @@ const headers = [
     column: "createdAt",
     text: "Date de déclaration de l’EIG",
     format: (value: { createdAt?: string }) =>
-      dayjs(value.createdAt).format("DD/MM/YYYY"),
+      value?.createdAt ? formatFR(new Date(value.createdAt)) : "",
     sort: true,
   },
   { column: "departement", text: "Territoire", sort: true },
@@ -333,7 +324,8 @@ const headers = [
     column: "dateDebut",
     text: "Dates (Début-fin)",
     format: (value: { dateDebut?: string; dateFin?: string }) =>
-      `${dayjs(value.dateDebut).format("DD/MM/YYYY")} - ${dayjs(value.dateFin).format("DD/MM/YYYY")}`,
+      `${value?.dateDebut ? formatFR(new Date(value.dateDebut)) : ""} - ${value?.dateFin ? formatFR(new Date(value.dateFin)) : ""}`,
+
     sort: true,
   },
   {
@@ -350,7 +342,7 @@ const headers = [
     column: "date",
     text: "Dates de l'incident",
     format: (value: { date?: string }) =>
-      dayjs(value.date).format("DD/MM/YYYY"),
+      value?.date ? formatFR(new Date(value.date)) : "",
     sort: true,
   },
   {

--- a/packages/frontend-usagers/src/pages/eig/liste.vue
+++ b/packages/frontend-usagers/src/pages/eig/liste.vue
@@ -65,12 +65,26 @@
                 />
               </div>
             </div>
-            <div
-              class="fr-fieldset__element fr-fieldset__element--inline fr-col-12 fr-col-md-3 fr-col-lg-2"
-            >
-              <RangeDatePicker
-                v-model="searchState.dateRange"
-                label="Date de l'eig"
+          </div>
+          <div class="fr-fieldset fr-grid-row fr-grid-row--gutters">
+            <div class="fr-fieldset__element fr-col-12 fr-col-md-3 fr-col-lg-2">
+              <label class="fr-label" for="date-start">Date de l’EIG du</label>
+              <span class="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
+              <input
+                id="date-start"
+                v-model="searchState.startAt"
+                class="fr-input"
+                type="date"
+              />
+            </div>
+            <div class="fr-fieldset__element fr-col-12 fr-col-md-3 fr-col-lg-2">
+              <label class="fr-label" for="date-end">au</label>
+              <span class="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
+              <input
+                id="date-end"
+                v-model="searchState.endAt"
+                class="fr-input"
+                type="date"
               />
             </div>
           </div>
@@ -108,12 +122,11 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import dayjs from "dayjs";
 import {
   eigModel,
   EigTypeListe,
-  RangeDatePicker,
   TableWithBackendPagination,
   ValidationModal,
   eigUtils,
@@ -121,11 +134,32 @@ import {
   useToaster,
 } from "@vao/shared-ui";
 import { getEigPermissions, canDelete } from "../../utils/eig";
+
 const mapEigToLabel = eigUtils.mapEigToLabel;
+
+defineOptions({
+  name: "ListeEigPage",
+});
 
 definePageMeta({
   middleware: ["is-connected", "check-roles"],
 });
+
+type SortState = {
+  sortBy?: string;
+  sortDirection?: string;
+};
+
+type SearchPayload = {
+  libelle: string | null;
+  statut: string | null;
+  idFonctionnelle: string | null;
+  type: string | null;
+  startAt: string | null;
+  endAt: string | null;
+};
+
+type SearchFilterKey = "libelle" | "statut" | "idFonctionnelle" | "type";
 
 const eig = reactive({
   allowEigReadWrite: false,
@@ -134,8 +168,8 @@ const eig = reactive({
 });
 
 const { allowEigReadWrite, allowEigReadOnly } = getEigPermissions();
-eig.allowEigReadWrite = allowEigReadWrite;
-eig.allowEigReadOnly = allowEigReadOnly;
+eig.allowEigReadWrite = allowEigReadWrite ?? false;
+eig.allowEigReadOnly = allowEigReadOnly ?? false;
 
 const DsfrButton = resolveComponent("DsfrButton");
 
@@ -146,55 +180,78 @@ const defaultLimit = 10;
 const defaultOffset = 0;
 
 const allStatus = "Tous les statuts";
-const sortState = ref({});
-const currentPageState = ref(defaultOffset);
-const limitState = ref(defaultLimit);
-const searchState = reactive({
+const sortState = ref<SortState>({});
+const currentPageState = ref<number>(defaultOffset);
+const limitState = ref<number>(defaultLimit);
+const searchState = reactive<SearchPayload>({
   libelle: null,
   statut: null,
   idFonctionnelle: null,
   type: null,
-  dateRange: null,
+  startAt: null,
+  endAt: null,
 });
+const isValidDate = (value: string | null) => {
+  if (!value) return false;
 
-const paginateResults = async (sortValue, limitValue, currentPageValue) => {
+  // format exact YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+};
+
+const buildSearchParam = (search: SearchPayload) =>
+  JSON.stringify({
+    ...search,
+    startAt: isValidDate(search.startAt) ? search.startAt : null,
+    endAt: isValidDate(search.endAt) ? search.endAt : null,
+  });
+
+const paginateResults = async (
+  sortValue: SortState,
+  limitValue: number,
+  currentPageValue: number,
+) => {
   try {
     await eigStore.get({
       sortBy: sortValue.sortBy,
       sortDirection: sortValue.sortDirection,
       limit: limitValue,
       offset: currentPageValue * limitValue,
-      search: searchState,
+      search: buildSearchParam(searchState),
     });
   } catch (error) {
     toaster.error({
-      description: "Une erreur est survenue lors de la récupération de la demande",
+      description:
+        "Une erreur est survenue lors de la récupération de la demande",
       role: "alert",
     });
     throw error;
   }
 };
 
-const fetchEigDebounce = debounce(async (search) => {
+const fetchEigDebounce = debounce(async () => {
   try {
     await eigStore.get({
       sortBy: sortState.value.sortBy,
       sortDirection: sortState.value.sortDirection,
       limit: limitState.value,
       offset: currentPageState.value * limitState.value,
-      search,
+      search: buildSearchParam(searchState),
     });
   } catch (error) {
     toaster.error({
-      description: "Une erreur est survenue lors de la récupération de la demande",
+      description:
+        "Une erreur est survenue lors de la récupération de la demande",
       role: "alert",
     });
     throw error;
   }
 });
 
-watch([searchState], ([searchValue]) => {
-  fetchEigDebounce(searchValue);
+watch([searchState], () => {
+  void fetchEigDebounce();
 });
 
 const status = [
@@ -206,35 +263,41 @@ const status = [
 const typesOption = [
   allStatus,
   ...[
-    ...Object.values(eigModel.Types[eigModel.Categorie.VICTIMES]).map((t) => ({
-      text:
-        mapEigToLabel[t] +
-        (t === eigModel.Types[eigModel.Categorie.VICTIMES].AUTRE
-          ? " (victime)"
-          : ""),
-      value: t,
-    })),
-    ...Object.values(eigModel.Types[eigModel.Categorie.SANTE]).map((t) => ({
-      text:
-        mapEigToLabel[t] +
-        (t === eigModel.Types[eigModel.Categorie.SANTE].AUTRE
-          ? " (santé)"
-          : ""),
-      value: t,
-    })),
-    ...Object.values(eigModel.Types[eigModel.Categorie.SECURITE]).map((t) => ({
-      text:
-        mapEigToLabel[t] +
-        (t === eigModel.Types[eigModel.Categorie.SECURITE].AUTRE
-          ? " (sécurité)"
-          : ""),
-      value: t,
-    })),
+    ...Object.values(eigModel.Types[eigModel.Categorie.VICTIMES]).map(
+      (t: string) => ({
+        text:
+          mapEigToLabel[t as keyof typeof mapEigToLabel] +
+          (t === eigModel.Types[eigModel.Categorie.VICTIMES].AUTRE
+            ? " (victime)"
+            : ""),
+        value: t,
+      }),
+    ),
+    ...Object.values(eigModel.Types[eigModel.Categorie.SANTE]).map(
+      (t: string) => ({
+        text:
+          mapEigToLabel[t as keyof typeof mapEigToLabel] +
+          (t === eigModel.Types[eigModel.Categorie.SANTE].AUTRE
+            ? " (santé)"
+            : ""),
+        value: t,
+      }),
+    ),
+    ...Object.values(eigModel.Types[eigModel.Categorie.SECURITE]).map(
+      (t: string) => ({
+        text:
+          mapEigToLabel[t as keyof typeof mapEigToLabel] +
+          (t === eigModel.Types[eigModel.Categorie.SECURITE].AUTRE
+            ? " (sécurité)"
+            : ""),
+        value: t,
+      }),
+    ),
     ...Object.values(
       eigModel.Types[eigModel.Categorie.FONCTIONNEMENT_ORGANISME],
-    ).map((t) => ({
+    ).map((t: string) => ({
       text:
-        mapEigToLabel[t] +
+        mapEigToLabel[t as keyof typeof mapEigToLabel] +
         (t === eigModel.Types[eigModel.Categorie.FONCTIONNEMENT_ORGANISME].AUTRE
           ? " (fonctionnement organisme)"
           : ""),
@@ -242,12 +305,9 @@ const typesOption = [
     })),
   ].sort((t1, t2) => (t1.text < t2.text ? -1 : 1)),
 ];
-const onSelect = (value, key) => {
-  if (value === allStatus) {
-    searchState[key] = null;
-  } else {
-    searchState[key] = value;
-  }
+const onSelect = (value: string | number | null, key: SearchFilterKey) => {
+  const nextValue = value === allStatus ? null : String(value);
+  searchState[key] = nextValue;
 };
 
 const headers = [
@@ -259,11 +319,11 @@ const headers = [
   {
     column: "createdAt",
     text: "Date de déclaration de l’EIG",
-    format: (value) => dayjs(value.createdAt).format("DD/MM/YYYY"),
+    format: (value: { createdAt?: string }) =>
+      dayjs(value.createdAt).format("DD/MM/YYYY"),
     sort: true,
   },
   { column: "departement", text: "Territoire", sort: true },
-
   {
     column: "libelle",
     text: "Séjour",
@@ -272,22 +332,25 @@ const headers = [
   {
     column: "dateDebut",
     text: "Dates (Début-fin)",
-    format: (value) =>
+    format: (value: { dateDebut?: string; dateFin?: string }) =>
       `${dayjs(value.dateDebut).format("DD/MM/YYYY")} - ${dayjs(value.dateFin).format("DD/MM/YYYY")}`,
     sort: true,
   },
   {
     column: "types",
     text: "Types d'événement",
-    component: ({ types }) => ({
+    component: ({ types }: { types?: Array<string | null> | null }) => ({
       component: EigTypeListe,
-      types: (types ?? []).map((t) => mapEigToLabel[t]),
+      types: (types ?? []).map((t: string | null) =>
+        t ? mapEigToLabel[t as keyof typeof mapEigToLabel] : "",
+      ),
     }),
   },
   {
     column: "date",
     text: "Dates de l'incident",
-    format: (value) => dayjs(value.date).format("DD/MM/YYYY"),
+    format: (value: { date?: string }) =>
+      dayjs(value.date).format("DD/MM/YYYY"),
     sort: true,
   },
   {
@@ -299,9 +362,15 @@ const headers = [
       readByDdets,
       agrementRegionObtention,
       departement,
+    }: {
+      statut?: string;
+      readByDreets?: boolean;
+      readByDdets?: boolean;
+      agrementRegionObtention?: string | null;
+      departement?: string | null;
     }) => ({
       component: EigStatusBadge,
-      statut: statut,
+      statut,
       dreets: { isRead: readByDreets, territoireCode: agrementRegionObtention },
       ddets: { isRead: readByDdets, territoireCode: departement },
     }),
@@ -309,12 +378,12 @@ const headers = [
   },
   {
     text: "Actions",
-    component: ({ statut, id }) => ({
+    component: ({ statut, id }: { statut?: string; id?: string }) => ({
       component: DsfrButton,
       disabled: !(eig.canDelete(statut) && eig.allowEigReadWrite),
-      onClick: (event) => {
+      onClick: (event: MouseEvent) => {
         event.stopPropagation();
-        eigToDelete.value = id;
+        eigToDelete.value = id ?? null;
       },
       label: "Suppression",
       iconOnly: true,
@@ -323,32 +392,48 @@ const headers = [
   },
 ];
 
-const updateSort = ({ sortBy: sb, sortDirection: sd }) => {
+const updateSort = ({ sortBy: sb, sortDirection: sd }: SortState) => {
   sortState.value = {
     sortBy: sb,
     sortDirection: sd,
   };
-  paginateResults(sortState.value, limitState.value, currentPageState.value);
+  void paginateResults(
+    sortState.value,
+    limitState.value,
+    currentPageState.value,
+  );
 };
-const updateItemsByPage = (val) => {
-  limitState.value = parseInt(val);
-  paginateResults(sortState.value, limitState.value, currentPageState.value);
+const updateItemsByPage = (val: string | number) => {
+  limitState.value = parseInt(String(val), 10);
+  void paginateResults(
+    sortState.value,
+    limitState.value,
+    currentPageState.value,
+  );
 };
-const updateCurrentPage = (val) => {
+const updateCurrentPage = (val: number) => {
   currentPageState.value = val;
-  paginateResults(sortState.value, limitState.value, currentPageState.value);
+  void paginateResults(
+    sortState.value,
+    limitState.value,
+    currentPageState.value,
+  );
 };
 
-const navigate = (state) => {
+const navigate = (state: { id: string; statut?: string }) => {
   navigateTo(
     `/eig/${state.id}${state.statut !== eigModel.Statuts.BROUILLON ? "#eig-recap" : ""}`,
   );
 };
 
-const eigToDelete = ref(null);
+const eigToDelete = ref<string | null>(null);
 
 const closeEigModal = () => (eigToDelete.value = null);
 const deleteEig = async () => {
+  if (!eigToDelete.value) {
+    return;
+  }
+
   try {
     await eigStore.delete(eigToDelete.value);
     await eigStore.get();
@@ -367,7 +452,7 @@ try {
   await eigStore.get({
     limit: defaultLimit,
     offset: defaultOffset,
-    search: searchState,
+    search: buildSearchParam(searchState),
   });
 } catch (error) {
   toaster.error({

--- a/packages/frontend-usagers/src/stores/eig.ts
+++ b/packages/frontend-usagers/src/stores/eig.ts
@@ -112,7 +112,7 @@ export const useEigStore = defineStore("eig", {
       offset?: number;
       sortBy?: string;
       sortDirection?: string;
-      search?: Record<string, unknown>;
+      search?: string;
     } = {}) {
       log.i("fetchEig - IN");
       try {

--- a/packages/shared-bridge/src/routes/usagers/eig/get.ts
+++ b/packages/shared-bridge/src/routes/usagers/eig/get.ts
@@ -38,6 +38,7 @@ export interface GetUsagersRoute extends BasicRoute {
       startAt?: Date | null;
       endAt?: Date | null;
       type?: string | string[] | null;
+      departement?: string | null;
     };
   };
   response: RouteResponseBody<{
@@ -52,6 +53,7 @@ export const GetUsagersRouteSchema: RouteSchema<GetUsagersRoute> = {
     search: yup
       .object({
         createdAt: yup.date().nullable().optional(),
+        departement: yup.string().nullable().optional(),
         endAt: yup.date().nullable().optional(),
         id: yup.string().nullable().optional(),
         idFonctionnelle: yup.string().nullable().optional(),

--- a/packages/shared-bridge/src/routes/usagers/eig/get.ts
+++ b/packages/shared-bridge/src/routes/usagers/eig/get.ts
@@ -12,10 +12,12 @@ export const EIG_USAGERS_SORT_COLUMNS = [
   "libelle",
   "statut",
   "id",
+  "date",
   "dateDebut",
   "dateFin",
   "idFonctionnelle",
   "createdAt",
+  "departement",
 ] as const;
 
 export type EigUsagersSortColumn = (typeof EIG_USAGERS_SORT_COLUMNS)[number];
@@ -33,7 +35,8 @@ export interface GetUsagersRoute extends BasicRoute {
       statut?: string | string[] | null;
       idFonctionnelle?: string | null;
       id?: string | null;
-      createdAt?: Date | null;
+      startAt?: Date | null;
+      endAt?: Date | null;
       type?: string | string[] | null;
     };
   };
@@ -49,9 +52,11 @@ export const GetUsagersRouteSchema: RouteSchema<GetUsagersRoute> = {
     search: yup
       .object({
         createdAt: yup.date().nullable().optional(),
+        endAt: yup.date().nullable().optional(),
         id: yup.string().nullable().optional(),
         idFonctionnelle: yup.string().nullable().optional(),
         libelle: yup.string().nullable().optional(),
+        startAt: yup.date().nullable().optional(),
         statut: stringOrStringArray.optional(),
         type: stringOrStringArray.optional(),
       })

--- a/packages/shared-bridge/src/utils/date.spec.ts
+++ b/packages/shared-bridge/src/utils/date.spec.ts
@@ -13,6 +13,7 @@ import {
   isBefore,
   isBetweenDates,
   isValidFrShort,
+  isValidIsoShort,
   minutesBetween,
   parseFrShort,
   parseIntToMonthFR,
@@ -309,5 +310,41 @@ describe("formatISOShort", () => {
     expect(fromFr).toBeDefined();
     expect(Number.isNaN(fromFr!.toDate().getTime())).toBe(false);
     expect(formatISOShort(fromFr)).toBe("2026-03-16");
+  });
+});
+
+describe("isValidIsoShort", () => {
+  it("retourne false si date est undefined", () => {
+    expect(isValidIsoShort(undefined)).toBe(false);
+  });
+
+  it("retourne false si date est null", () => {
+    expect(isValidIsoShort(null)).toBe(false);
+  });
+
+  it("retourne false si date est une chaîne vide", () => {
+    expect(isValidIsoShort("")).toBe(false);
+  });
+
+  it("retourne true pour une date valide au format YYYY-MM-DD", () => {
+    expect(isValidIsoShort("2024-01-15")).toBe(true);
+    expect(isValidIsoShort("2000-02-29")).toBe(true); // année bissextile
+  });
+
+  it("retourne false pour une date invalide", () => {
+    expect(isValidIsoShort("2024-02-30")).toBe(false);
+    expect(isValidIsoShort("2023-13-01")).toBe(false);
+    expect(isValidIsoShort("2023-00-10")).toBe(false);
+  });
+
+  it("retourne false si le format n'est pas YYYY-MM-DD", () => {
+    expect(isValidIsoShort("15-01-2024")).toBe(false);
+    expect(isValidIsoShort("2024/01/15")).toBe(false);
+    expect(isValidIsoShort("20240115")).toBe(false);
+  });
+
+  it("retourne false pour des valeurs non date", () => {
+    expect(isValidIsoShort("hello")).toBe(false);
+    expect(isValidIsoShort("123")).toBe(false);
   });
 });

--- a/packages/shared-bridge/src/utils/date.ts
+++ b/packages/shared-bridge/src/utils/date.ts
@@ -114,6 +114,11 @@ export const isValidFrShort = (date?: string | null): boolean => {
   return dayjs(date, "DD/MM/YYYY", true).isValid();
 };
 
+export const isValidIsoShort = (date?: string | null): boolean => {
+  if (!date) return false;
+  return dayjs(date, "YYYY-MM-DD", true).isValid();
+};
+
 export const parseFrShort = (date?: string | null): dayjs.Dayjs | undefined => {
   if (!date) return undefined;
   const parsed = dayjs(date, "DD/MM/YYYY", true);


### PR DESCRIPTION
## Ticket(s) lié(s)
1294

## Description
Permettre à l'OVA principal de voir l'ensemble des EIG de son OVA ainsi que de tous les établissements secondaire
Les OVA secondaires gardent la visibilité sur leur seules EIG
Modification au passage du DatePicker défaillant pour le remplacer par deux champs dates

## Screenshot / liens loom 
<img width="1258" height="521" alt="image" src="https://github.com/user-attachments/assets/b1faf3cd-39a7-474d-b546-41ea0aab739e" />

## Check-list

 - [W] Ma branche est rebase sur main
 - [X] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [X] Plus de `console.log`
 - [X] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [X] J'ai converti les fichiers vue en `<script lang="ts">`
 - [X] Mon code est en Typescript (autant que possible)

**Testing instructions**
    ${{ Test the following }}
    - [x] Se connecter avec un OVA Principal : tous les EIG doivent être visibles
    - [x] Se connecter avec un OVA secondaire : Seuls les EIG de l'organisme sont visible
