### PR TITLE
feat: 1302 modification premier agrement ova suite demande de complem…

### DIFF
--- a/packages/backend/src/__tests__/usagers/agrements.test.ts
+++ b/packages/backend/src/__tests__/usagers/agrements.test.ts
@@ -784,6 +784,15 @@ describe("POST /agrements", () => {
         id: agrementId,
         statut: AGREMENT_STATUT.TRANSMIS,
       });
+    const calls = (mailService.send as jest.Mock).mock.calls;
+    const mailToRegion = calls[3]; // mail région après renvoi post-A_COMPLETER
+    expect(mailToRegion[0].subject).toBe(
+      "Portail VAO – Nouvelle demande de renouvellement d'agrément reçue",
+    );
+    expect(mailToRegion[0].html).toContain(
+      "après avoir apporté les modifications demandées",
+    );
+    expect(mailToRegion[0].html).toContain("Transmis");
     expect(responseCorrection.status).toBe(200);
     expect(responseCorrection.body.id).toBe(agrementId);
     expect(mailService.send).toHaveBeenCalledTimes(5);
@@ -799,6 +808,69 @@ describe("POST /agrements", () => {
     expect(aModifierEvent?.usager_user).toBeDefined();
     const { agrement } = await getAgrement(agrementId);
     expect(agrement?.statut).toBe(AGREMENT_STATUT.TRANSMIS);
+  });
+
+  it("devrait envoyer le mail 'première demande' à la région après renvoi suite à demande de complément", async () => {
+    const usagerUser = await createUsagersUser();
+    // Ici on répond aux conditions de mise à jour backOffice
+    const adminUser = await createAdminUser();
+    await createTerritoire({ territoireCode: "IDF" });
+    const organismeId = await createOrganisme({ userId: usagerUser.id });
+    await createTerritoire({
+      territoire: { service_mail: "region-idf@example.com" },
+      territoireCode: "IDF",
+    });
+
+    const agrementData = await buildAgrementFixture({
+      organismeId,
+      statut: AGREMENT_STATUT.BROUILLON,
+    });
+    const agrementId = await createAgrement({
+      agrement: agrementData,
+      organismeId,
+    });
+    const response = await request(getFoAppHelper(usagerUser))
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+        typeDepot: AGREMENT_TYPE_DEPOT.PREMIER,
+      });
+
+    expect(mailService.send).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(agrementId);
+
+    // Mise à jour côté Admin pour demande de complétion du dossier
+    await AgrementServiceAdmin.updateStatut({
+      agrementId,
+      boUserId: String(adminUser.id),
+      commentaire:
+        "Dossier à compléter car il manque des éléments pour pouvoir le traiter",
+      statut: AGREMENT_STATUT.A_COMPLETER,
+      territoireCode: agrementData.regionObtention!,
+    });
+    expect(mailService.send).toHaveBeenCalledTimes(3);
+
+    // Transmission de l'agrément au Service après complétude
+    await request(getFoAppHelper(usagerUser))
+      .post(`/agrements/`)
+      .send({
+        ...agrementData,
+        id: agrementId,
+        statut: AGREMENT_STATUT.TRANSMIS,
+        typeDepot: AGREMENT_TYPE_DEPOT.PREMIER,
+      });
+    const calls = (mailService.send as jest.Mock).mock.calls;
+    const mailToRegion = calls[3];
+    expect(mailToRegion[0].subject).toBe(
+      "Portail VAO – Nouvelle demande de premier agrément reçue",
+    );
+    expect(mailToRegion[0].html).toContain(
+      "après avoir apporté les modifications demandées",
+    );
+    expect(mailToRegion[0].html).toContain("1ère demande en cours");
   });
 
   it("devrait changer le statut en agrement EN_INSTRUCTION après demande de correction", async () => {

--- a/packages/backend/src/admin/agrements/agrements.mail.ts
+++ b/packages/backend/src/admin/agrements/agrements.mail.ts
@@ -144,7 +144,7 @@ export const AgrementMailAdmin = {
     const isPremiereDemande = typeDepot === AGREMENT_TYPE_DEPOT.PREMIER;
 
     const subject = isPremiereDemande
-      ? "Portail VAO – Nouvelle première demande d'agrément reçue"
+      ? "Portail VAO – Nouvelle demande de premier agrément reçue"
       : "Portail VAO – Nouvelle demande de renouvellement d'agrément reçue";
 
     const introText = isPremiereDemande

--- a/packages/backend/src/admin/agrements/agrements.mail.ts
+++ b/packages/backend/src/admin/agrements/agrements.mail.ts
@@ -134,42 +134,51 @@ export const AgrementMailAdmin = {
     email,
     organismeName,
     agrementId,
+    typeDepot,
   }: {
     email: string;
     organismeName: string;
     agrementId: number;
+    typeDepot: AGREMENT_TYPE_DEPOT;
   }) => {
-    log.i("sendStatutModificationTransmisRegionMail - In", {
-      agrementId,
-      email,
-      organismeName,
-    });
+    const isPremiereDemande = typeDepot === AGREMENT_TYPE_DEPOT.PREMIER;
+
+    const subject = isPremiereDemande
+      ? "Portail VAO – Nouvelle demande de première demande d’agrément reçue"
+      : "Portail VAO – Nouvelle demande de renouvellement d’agrément reçue";
+
+    const introText = isPremiereDemande
+      ? `L’OVA <strong>${organismeName}</strong> a renvoyé sa première demande d’agrément après avoir apporté les modifications demandées.`
+      : `L’OVA <strong>${organismeName}</strong> a renvoyé sa demande de renouvellement d’agrément après avoir apporté les modifications demandées.`;
+
+    const statutLabel = isPremiereDemande
+      ? "1ère demande en cours"
+      : "Transmis";
+
     const html = sendTemplate.getBody(
-      "Portail VAO – Nouvelle demande de renouvellement d’agrément reçue",
+      subject,
       [
         {
           p: [
             "Bonjour,",
-            `L’OVA <strong>${organismeName}</strong> a renvoyé sa demande de renouvellement d’agrément après avoir apporté les modifications demandées.`,
+            introText,
             "Vous pouvez désormais reprendre l’instruction de la demande, accessible via votre espace sur le portail VAO :",
             `<a href='${config.frontBODomain}/agrements/${agrementId}'>Lien direct vers le dossier</a>`,
-            "Le dossier est retourné au statut <strong>« Transmis »</strong> et peut être analysé à partir de l’étape « Vérification et confirmation de la complétude du dossier ».",
+            `Le dossier est retourné au statut <strong>« ${statutLabel} »</strong> et peut être analysé à partir de l’étape « Vérification et confirmation de la complétude du dossier ».`,
           ],
           type: "p",
         },
       ],
       `<br>L’équipe du SI VAO<br><a href='${config.frontBODomain}'>Portail VAO</a>`,
     );
-    const params = {
+
+    return {
       from: config.senderEmail,
       html,
       replyTo: config.senderEmail,
-      subject:
-        "Portail VAO – Nouvelle demande de renouvellement d’agrément reçue",
+      subject,
       to: email,
     };
-    log.d("sendStatutModificationTransmisRegionMail post email", { params });
-    return params;
   },
   sendStatutTransmisRegionMail: ({
     email,

--- a/packages/backend/src/admin/agrements/agrements.mail.ts
+++ b/packages/backend/src/admin/agrements/agrements.mail.ts
@@ -144,8 +144,8 @@ export const AgrementMailAdmin = {
     const isPremiereDemande = typeDepot === AGREMENT_TYPE_DEPOT.PREMIER;
 
     const subject = isPremiereDemande
-      ? "Portail VAO – Nouvelle demande de première demande d’agrément reçue"
-      : "Portail VAO – Nouvelle demande de renouvellement d’agrément reçue";
+      ? "Portail VAO – Nouvelle première demande d'agrément reçue"
+      : "Portail VAO – Nouvelle demande de renouvellement d'agrément reçue";
 
     const introText = isPremiereDemande
       ? `L’OVA <strong>${organismeName}</strong> a renvoyé sa première demande d’agrément après avoir apporté les modifications demandées.`

--- a/packages/backend/src/usagers/agrements/agrements.service.ts
+++ b/packages/backend/src/usagers/agrements/agrements.service.ts
@@ -296,6 +296,7 @@ export const AgrementService = {
                     agrementId,
                     email: emailRegion,
                     organismeName,
+                    typeDepot: agrement.typeDepot,
                   });
               await mailService.send(mailToSend);
             }

--- a/packages/frontend-usagers/src/components/agrement/a-modifier.vue
+++ b/packages/frontend-usagers/src/components/agrement/a-modifier.vue
@@ -18,7 +18,7 @@
     </h2>
 
     La DREETS en charge de l'instruction de votre dossier d'agrément vous
-    sollicite pour des compléments d'informations Accédes à votre agrément,
+    sollicite pour des compléments d'informations. Accédez à votre agrément,
     complétez le puis transmettez le à nouveau à votre DREETS qui reprendra
     l'instruction du dossier<br /><br />
     <strong>Commentaire de la DREETS :</strong><br />


### PR DESCRIPTION
…ents

## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336?selectedIssue=VAO-1302

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Permet à l'ova de modifier son premier agrement après demande de complements par la DREETS. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 
<img width="961" height="569" alt="Capture d’écran 2026-07-20 à 18 14 19" src="https://github.com/user-attachments/assets/2d3d9d6d-df4f-450b-9f42-ec17108497ee" />

**Incohérence potentielle sur le libellé de statut dans le mail DREETS (première demande)**

Dans le cadre de cette feature, le mail envoyé à la DREETS après renvoi d'une première demande d'agrément modifiée indique que *"le dossier est retourné au statut « 1ère demande en cours »"*, conformément au modèle fourni dans le ticket.

Cependant, ce libellé ne correspond à aucune valeur de l'enum technique `AGREMENT_STATUT` : le statut réellement enregistré en base et affiché ailleurs dans l'application (badge sur la page "Mon agrément" côté OVA, via le composant `AgrementStatusBadge`) est **`TRANSMIS`**, affiché sous le libellé **"Transmis"**.

Le composant `AgrementStatusBadge` ne prend pas en compte le `typeDepot` (première demande vs renouvellement) dans sa logique d'affichage : il associe un unique libellé par valeur de statut technique, indépendamment du contexte métier. Résultat : un OVA ou un agent DREETS pourrait lire "1ère demande en cours" dans un email, puis ne retrouver que "Transmis" affiché dans l'application — sans lien évident entre les deux.

- Doit-on harmoniser l'affichage du badge de statut pour qu'il tienne compte du `typeDepot` (afficher "1ère demande en cours" pour les statuts `TRANSMIS` en contexte premier agrément) ?
- Ou doit-on au contraire aligner le texte du mail sur le libellé technique existant ("Transmis") pour rester cohérent avec ce qui est déjà affiché dans l'app ?

## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [x] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
