### PR TITLE
fix: 1458 bouton refus validation compte

### DIFF
--- a/packages/frontend-usagers/src/components/user/liste.vue
+++ b/packages/frontend-usagers/src/components/user/liste.vue
@@ -237,6 +237,7 @@ const closeRefusModal = () => {
 
 async function refused({ commentaire }: { commentaire: string }) {
   if (!utilisateurSelectionne.value) {
+    console.error("No user selected for refusal");
     return;
   }
 
@@ -245,10 +246,28 @@ async function refused({ commentaire }: { commentaire: string }) {
     motif: commentaire,
   } as Partial<UserDto>;
 
-  await userStore.updateUserStatus(utilisateurSelectionne.value.id, params);
-  userStore.fetchUsersOrganisme(query);
-  utilisateurSelectionne.value = null;
-  showRefusModal.value = false;
+  try {
+    await userStore.updateUserStatus(
+      utilisateurSelectionne.value.userId,
+      params,
+    );
+    toaster.success({
+      titleTag: "h2",
+      description:
+        "La demande de création de compte a été refusée. L'utilisateur va recevoir un mail pour le prévenir.",
+    });
+    userStore.fetchUsersOrganisme(query);
+  } catch (err) {
+    toaster.error({
+      titleTag: "h2",
+      description: "Erreur lors de la mise à jour du status de l'utilisateur.",
+      role: "alert",
+    });
+    throw err;
+  } finally {
+    utilisateurSelectionne.value = null;
+    showRefusModal.value = false;
+  }
 }
 
 function openCompte(userId: string) {


### PR DESCRIPTION
## Ticket(s) lié(s)
https://jira-mcas.atlassian.net/jira/software/c/projects/VAO/boards/336?selectedIssue=VAO-1458

<!-- If you have a Jira Ticket / Sentry Ticket / GitHub Issue -->

## Description
Le bouton de refus d'un ova ne fonctionnait plus. Mentionné pour le refus d'un etablissement secondaire mais le bug devait être présent pour tout type de user. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

## Screenshot / liens loom 
<img width="1388" height="741" alt="Capture d’écran 2026-07-24 à 18 04 32" src="https://github.com/user-attachments/assets/3096e300-5294-4543-88ff-0826f2642182" />


## Check-list

 - [x] Ma branche est rebase sur main
 - [ ] Des tests ont été écrits pour tous les endpoints créés ou modifiés
 - [ ] Refacto "à la volée" des parties sur lesquelles j'ai codée
 - [x] Plus de `console.log`
 - [ ] J'ai ajouté une validation de schéma sur la route que j'ai ajouté ou modifié
 - [ ] J'ai converti les fichiers vue en `<script lang="ts">`
 - [ ] Mon code est en Typescript (autant que possible)

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
